### PR TITLE
Fix game start flow and add GitHub Pages base

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -594,10 +594,13 @@ function startGame(color) {
     dice: rollForInitiative(),
   };
   game.currentPlayer = game.dice.winner;
+  state.game = game;
+  state.screen = 'game';
   addLog(
     `Initiative roll — You: ${game.dice.player}, AI: ${game.dice.ai}. ${game.currentPlayer === 0 ? 'You go first.' : 'AI goes first.'}`,
     game,
   );
+  addLog(`AI Opponent will wield the ${COLORS[aiColor].name} deck.`, game);
   drawCards(player, 5);
   drawCards(ai, 5);
   if (game.currentPlayer === 0) {
@@ -606,8 +609,6 @@ function startGame(color) {
     beginTurn(game.currentPlayer);
     setTimeout(() => runAI(), 700);
   }
-  state.game = game;
-  state.screen = 'game';
   render();
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: '/fightcards/',
+});


### PR DESCRIPTION
## Summary
- ensure the game state is created before the first turn begins so deck selection starts a match immediately
- log the AI's chosen deck color when a duel starts for clarity
- configure Vite with the repository base path for GitHub Pages deployment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2bef486e0832a8010d09020262532