### PR TITLE
Configure InstantDB ID env for build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
         run: npm ci
 
       - name: Build project
+        env:
+          VITE_INSTANTDB_ID: ${{ vars.VITE_INSTANTDB_ID }}
         run: npm run build
 
       - name: Upload Pages artifact


### PR DESCRIPTION
## Summary
- set the Build project step to read the InstantDB app ID from the repository-level Actions variable VITE_INSTANTDB_ID

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2dbbbfacc832ab43f67f3d277b5c3