### PR TITLE
Improve combat flow, damage visuals, AI pacing, and mobile layout

### DIFF
--- a/src/app/game/creatures.js
+++ b/src/app/game/creatures.js
@@ -93,8 +93,16 @@ export function removeFromBattlefield(player, instanceId) {
 }
 
 export function dealDamageToCreature(creature, controllerIndex, amount) {
+  if (amount <= 0) return;
   const stats = getCreatureStats(creature, controllerIndex, state.game);
-  creature.damageMarked = (creature.damageMarked || 0) + amount;
+  const newDamage = (creature.damageMarked || 0) + amount;
+  creature.damageMarked = newDamage;
+  const remaining = Math.max(stats.toughness - newDamage, 0);
+  if (remaining > 0) {
+    addLog(`${creature.name} takes ${amount} damage (${remaining} toughness remaining).`);
+  } else {
+    addLog(`${creature.name} takes ${amount} damage.`);
+  }
   if (creature.damageMarked >= stats.toughness) {
     destroyCreature(creature, controllerIndex);
   }

--- a/src/app/game/interactions.js
+++ b/src/app/game/interactions.js
@@ -37,11 +37,11 @@ export function handleCreatureClick(cardId, controller) {
     handleTargetSelection(creature, controller);
     return;
   }
-  if (game.phase === 'combat' && game.currentPlayer === 0 && controller === 0) {
+  if (game.phase === 'combat' && game.currentPlayer === 0 && controller === 0 && game.combat?.stage === 'choose') {
     toggleAttacker(creature);
     return;
   }
-  if (game.blocking && game.currentPlayer === 1) {
+  if (game.blocking && game.currentPlayer === 1 && game.combat?.stage === 'blockers') {
     if (controller === 0) {
       if (game.blocking.selectedBlocker && game.blocking.selectedBlocker.instanceId === creature.instanceId) {
         game.blocking.selectedBlocker = null;

--- a/src/app/game/log.js
+++ b/src/app/game/log.js
@@ -12,9 +12,9 @@ export function addLog(message, gameOverride) {
 }
 
 export function getRecentLogEntries(game, count = 3) {
-  return game.log.slice(-count);
+  return game.log.slice(-count).reverse();
 }
 
 export function getFullLog(game) {
-  return [...game.log];
+  return [...game.log].reverse();
 }

--- a/src/app/ui/events.js
+++ b/src/app/ui/events.js
@@ -2,7 +2,6 @@ import { db, state, resetToMenu, requestRender } from '../state.js';
 import {
   startGame,
   advancePhase,
-  toggleCombatSelection,
   confirmAttackers,
   skipCombat,
   finalizeCurrentRequirement,
@@ -136,13 +135,6 @@ function bindGameEvents(root) {
   const declareBtn = root.querySelector('[data-action="declare-attackers"]');
   if (declareBtn) {
     declareBtn.addEventListener('click', () => {
-      toggleCombatSelection();
-    });
-  }
-
-  const resolveBtn = root.querySelector('[data-action="resolve-attacks"]');
-  if (resolveBtn) {
-    resolveBtn.addEventListener('click', () => {
       confirmAttackers();
     });
   }
@@ -168,7 +160,7 @@ function bindGameEvents(root) {
     });
   }
 
-  const resolveBlocksBtn = root.querySelector('[data-action="resolve-blocks"]');
+  const resolveBlocksBtn = root.querySelector('[data-action="declare-blocks"]');
   if (resolveBlocksBtn) {
     resolveBlocksBtn.addEventListener('click', () => {
       resolveCombat();

--- a/src/style.css
+++ b/src/style.css
@@ -5,6 +5,11 @@
   line-height: 1.4;
 }
 
+html,
+body {
+  height: 100%;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -271,6 +276,21 @@ input {
   box-shadow: 0 0 14px rgba(249, 115, 22, 0.4);
 }
 
+.card.attacker-card.attacker-blocked {
+  border-color: #fb923c;
+  box-shadow: 0 0 16px rgba(251, 146, 60, 0.45);
+}
+
+.card.blocker-selected {
+  border-color: #facc15;
+  box-shadow: 0 0 14px rgba(250, 204, 21, 0.45);
+}
+
+.card.blocking-creature {
+  border-color: #38bdf8;
+  box-shadow: 0 0 14px rgba(56, 189, 248, 0.35);
+}
+
 .card.blocker-selectable {
   border-color: #38bdf8;
 }
@@ -309,6 +329,24 @@ input {
   font-weight: 700;
   display: flex;
   justify-content: flex-end;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.card-footer .stat {
+  font-variant-numeric: tabular-nums;
+}
+
+.card-footer .stat.toughness.damaged {
+  color: #f87171;
+}
+
+.card-footer .damage-chip {
+  font-size: 0.7rem;
+  color: #fca5a5;
+  background: rgba(248, 113, 113, 0.18);
+  padding: 0.1rem 0.25rem;
+  border-radius: 0.4rem;
 }
 
 .ability {
@@ -381,6 +419,18 @@ input {
   font-size: 0.8rem;
 }
 
+.blocking-overlay ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.blocking-overlay .unblocked {
+  color: #f87171;
+}
+
 .pending-overlay button {
   margin-top: 0.2rem;
 }
@@ -398,16 +448,35 @@ input {
 
 button:disabled,
 button.disabled {
+  opacity: 0.4;
   cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
-@media (max-width: 540px) {
+@media (max-width: 600px) {
+  body {
+    align-items: flex-start;
+    padding: 0;
+  }
+
   #app {
     width: 100vw;
+    height: 100vh;
+    aspect-ratio: auto;
     border-radius: 0;
+    max-width: none;
     box-shadow: none;
   }
+
   .ui-layer {
-    padding: 0.8rem;
+    padding: 0.85rem;
+  }
+
+  .log-panel,
+  .battlefield-area,
+  .status-bar,
+  .hand-area {
+    border-radius: 14px;
   }
 }


### PR DESCRIPTION
## Summary
- update the combat UI to remove the extra attacker stage, add a defender blocking overlay, and display combat damage with red toughness values and damage chips
- slow the AI turn processing so actions happen at least a second apart and let the AI pause for player blocks while reversing log order for recent events
- tweak the mobile layout to fill the viewport without zooming and ensure damage marked on creatures resets each turn

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d313137270832ab41c4af0ebc690ab