### PR TITLE
Revamp battle log visuals and card presentation

### DIFF
--- a/src/app/game/ai.js
+++ b/src/app/game/ai.js
@@ -1,5 +1,5 @@
 import { state, requestRender } from '../state.js';
-import { addLog } from './log.js';
+import { addLog, cardSegment, playerSegment, textSegment } from './log.js';
 import { resolveCombat, skipCombat, triggerAttackPassive } from './combat.js';
 import { getCreatureStats } from './creatures.js';
 
@@ -87,7 +87,7 @@ function aiPlayTurnStep(aiPlayer) {
     }
     helpers.removeFromHand(aiPlayer, card.instanceId);
     helpers.spendMana(aiPlayer, card.cost ?? 0);
-    addLog(`${aiPlayer.name} casts ${card.name}.`);
+    addLog([playerSegment(aiPlayer), textSegment(' casts '), cardSegment(card), textSegment('.')]);
     const pending = {
       controller: 1,
       card,
@@ -168,7 +168,12 @@ function aiDeclareAttacks() {
   game.combat.attackers = attackers.map((creature) => ({ creature, controller: 1 }));
   game.combat.stage = 'blockers';
   attackers.forEach((creature) => {
-    helpers.addLog(`${game.players[1].name} sends ${creature.name} into battle.`);
+    helpers.addLog([
+      playerSegment(game.players[1]),
+      textSegment(' sends '),
+      cardSegment(creature),
+      textSegment(' into battle.'),
+    ]);
     triggerAttackPassive(creature, 1);
   });
   game.blocking = {
@@ -179,7 +184,7 @@ function aiDeclareAttacks() {
   };
   const blockers = game.players[0].battlefield.filter((c) => c.type === 'creature' && !c.summoningSickness);
   if (blockers.length === 0) {
-    addLog(`${game.players[0].name} has no blockers.`);
+    addLog([playerSegment(game.players[0]), textSegment(' has no blockers.')]);
     resolveCombat();
     return;
   }

--- a/src/app/game/creatures.js
+++ b/src/app/game/creatures.js
@@ -1,6 +1,6 @@
 import { createCardInstance } from '../../game/cards/index.js';
 import { state } from '../state.js';
-import { addLog } from './log.js';
+import { addLog, cardSegment, damageSegment, playerSegment, textSegment } from './log.js';
 
 let checkForWinnerHook = () => {};
 
@@ -48,7 +48,7 @@ export function bounceCreature(creature, controllerIndex) {
   removeFromBattlefield(player, creature.instanceId);
   creature.summoningSickness = !creature.abilities?.haste;
   player.hand.push(creature);
-  addLog(`${creature.name} returns to ${player.name}'s hand.`);
+  addLog([cardSegment(creature), textSegment(' returns to '), playerSegment(player), textSegment("'s hand.")]);
 }
 
 export function bounceStrongestCreatures(controllerIndex, amount) {
@@ -63,7 +63,7 @@ export function bounceStrongestCreatures(controllerIndex, amount) {
 export function freezeCreature(creature) {
   creature.frozenTurns = Math.max(1, creature.frozenTurns || 0);
   creature.summoningSickness = true;
-  addLog(`${creature.name} is frozen.`);
+  addLog([cardSegment(creature), textSegment(' is frozen.')]);
 }
 
 export function distributeSplashDamage(opponentIndex, amount) {
@@ -117,9 +117,14 @@ export function dealDamageToCreature(creature, controllerIndex, amount) {
   creature.damageMarked = newDamage;
   const remaining = Math.max(stats.toughness - newDamage, 0);
   if (remaining > 0) {
-    addLog(`${creature.name} takes ${amount} damage (${remaining} toughness remaining).`);
+    addLog([
+      cardSegment(creature),
+      textSegment(' takes '),
+      damageSegment(amount),
+      textSegment(` damage (${remaining} toughness remaining).`),
+    ]);
   } else {
-    addLog(`${creature.name} takes ${amount} damage.`);
+    addLog([cardSegment(creature), textSegment(' takes '), damageSegment(amount), textSegment(' damage.')]);
   }
   if (creature.damageMarked >= stats.toughness) {
     destroyCreature(creature, controllerIndex);
@@ -131,13 +136,18 @@ export function destroyCreature(creature, controllerIndex) {
   removeFromBattlefield(player, creature.instanceId);
   creature.damageMarked = 0;
   player.graveyard.push(creature);
-  addLog(`${creature.name} is defeated.`);
+  addLog([cardSegment(creature), textSegment(' dies.')]);
 }
 
 export function dealDamageToPlayer(index, amount) {
   const player = state.game.players[index];
   player.life -= amount;
-  addLog(`${player.name} takes ${amount} damage (life ${player.life}).`);
+  addLog([
+    playerSegment(player),
+    textSegment(' takes '),
+    damageSegment(amount),
+    textSegment(` damage (life ${player.life}).`),
+  ]);
   checkForWinnerHook();
 }
 

--- a/src/app/game/log.js
+++ b/src/app/game/log.js
@@ -2,20 +2,99 @@ import { state } from '../state.js';
 
 const MAX_LOG_ENTRIES = 200;
 
+export function textSegment(text) {
+  return { type: 'text', text };
+}
+
+export function playerSegment(player) {
+  if (!player) {
+    return textSegment('Unknown player');
+  }
+  return {
+    type: 'player',
+    id: player.id,
+    name: player.name,
+    color: player.color ?? 'neutral',
+  };
+}
+
+function snapshotCard(card) {
+  if (!card) return null;
+  return {
+    id: card.id ?? null,
+    name: card.name ?? 'Unknown Card',
+    type: card.type ?? 'card',
+    color: card.color ?? 'neutral',
+    cost: card.cost ?? null,
+    text: card.text ?? '',
+    baseAttack: card.baseAttack ?? card.attack ?? null,
+    baseToughness: card.baseToughness ?? card.toughness ?? null,
+    passive: card.passive ?? null,
+  };
+}
+
+export function cardSegment(card, extra = {}) {
+  if (!card) {
+    return {
+      type: 'card',
+      name: 'Unknown Card',
+      color: 'neutral',
+      cardType: 'card',
+      instanceId: null,
+      snapshot: null,
+      ...extra,
+    };
+  }
+  return {
+    type: 'card',
+    name: card.name,
+    color: card.color ?? 'neutral',
+    cardType: card.type ?? 'card',
+    instanceId: card.instanceId ?? null,
+    snapshot: snapshotCard(card),
+    ...extra,
+  };
+}
+
+export function damageSegment(amount) {
+  return { type: 'damage', amount };
+}
+
+export function healSegment(amount) {
+  return { type: 'heal', amount };
+}
+
+export function keywordSegment(text) {
+  return { type: 'keyword', text };
+}
+
+export function valueSegment(value, variant = 'default') {
+  return { type: 'value', value, variant };
+}
+
 export function addLog(message, gameOverride) {
   const target = gameOverride || state.game;
   if (!target) return;
-  target.log.push(message);
+  let entry;
+  if (Array.isArray(message)) {
+    entry = { segments: message };
+  } else if (message && typeof message === 'object' && Array.isArray(message.segments)) {
+    entry = message;
+  } else {
+    entry = { segments: [textSegment(String(message))] };
+  }
+  entry.timestamp = Date.now();
+  target.log.push(entry);
   if (target.log.length > MAX_LOG_ENTRIES) {
     target.log.splice(0, target.log.length - MAX_LOG_ENTRIES);
   }
 }
 
-export function getRecentLogEntries(game, count = 3) {
+export function getRecentLogEntries(game, count = 5) {
   return game.log.slice(-count).reverse();
 }
 
-export function getFullLog(game, recentCount = 3) {
+export function getFullLog(game, recentCount = 5) {
   const skip = Math.min(recentCount, game.log.length);
   return game.log.slice(0, game.log.length - skip).reverse();
 }

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -16,6 +16,7 @@ export const initialState = {
   game: null,
   ui: {
     logExpanded: false,
+    previewCard: null,
   },
 };
 
@@ -46,6 +47,7 @@ export function resetEmailLogin() {
 export function resetToMenu() {
   state.game = null;
   state.screen = 'menu';
+  state.ui.previewCard = null;
   requestRender();
 }
 

--- a/src/app/ui/events.js
+++ b/src/app/ui/events.js
@@ -174,4 +174,41 @@ function bindGameEvents(root) {
       activateCreatureAbility(creatureId);
     });
   });
+
+  root.querySelectorAll('.log-card-ref').forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      const instanceId = btn.getAttribute('data-card-ref');
+      const snapshotAttr = btn.getAttribute('data-card-snapshot');
+      let snapshot = null;
+      if (snapshotAttr) {
+        try {
+          snapshot = JSON.parse(decodeURIComponent(snapshotAttr));
+        } catch (error) {
+          console.warn('Failed to parse card snapshot', error);
+        }
+      }
+      state.ui.previewCard = { instanceId: instanceId || null, snapshot };
+      requestRender();
+    });
+  });
+
+  const previewOverlay = root.querySelector('.card-preview-overlay');
+  if (previewOverlay) {
+    previewOverlay.addEventListener('click', (event) => {
+      if (event.target.closest('[data-preview-dialog]')) {
+        return;
+      }
+      state.ui.previewCard = null;
+      requestRender();
+    });
+  }
+
+  root.querySelectorAll('[data-action="close-preview"]').forEach((btn) => {
+    btn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      state.ui.previewCard = null;
+      requestRender();
+    });
+  });
 }

--- a/src/style.css
+++ b/src/style.css
@@ -19,20 +19,33 @@ body {
   min-height: 100vh;
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   background: radial-gradient(circle at 20% 20%, #16213e, #05060f 60%);
+  padding: 0;
 }
 
 #app {
   position: relative;
-  width: min(100vw, 520px);
-  aspect-ratio: 9 / 16;
+  width: 100%;
+  height: 100vh;
   display: flex;
   justify-content: center;
   align-items: stretch;
   overflow: hidden;
-  border-radius: 18px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.6);
+  border-radius: 0;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+}
+
+@media (min-width: 900px) {
+  body {
+    padding: 2rem;
+  }
+
+  #app {
+    max-width: 1200px;
+    height: calc(100vh - 4rem);
+    border-radius: 24px;
+  }
 }
 
 #bg-canvas {
@@ -47,7 +60,7 @@ body {
   z-index: 2;
   width: 100%;
   height: 100%;
-  padding: 1.2rem;
+  padding: clamp(1rem, 2.5vw, 2rem);
   display: flex;
   flex-direction: column;
   overflow-y: auto;
@@ -188,14 +201,111 @@ input {
 .log-recent,
 .log-dropdown ul {
   margin: 0;
-  padding-left: 1.1rem;
-  font-size: 0.75rem;
-  line-height: 1.4;
+  padding-left: 0;
+  list-style: none;
+  font-size: 0.82rem;
+  line-height: 1.5;
 }
 
 .log-recent li,
 .log-dropdown li {
   margin-bottom: 0.35rem;
+  color: #e5e8ff;
+}
+
+.log-recent,
+.log-dropdown ul {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.log-player {
+  font-weight: 600;
+}
+
+.log-player.player-red {
+  color: #f43f5e;
+}
+
+.log-player.player-blue {
+  color: #3b82f6;
+}
+
+.log-player.player-green {
+  color: #22c55e;
+}
+
+.log-player.player-neutral {
+  color: #fef3c7;
+}
+
+.log-card-ref {
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-decoration: underline;
+  text-decoration-thickness: 2px;
+  text-decoration-color: rgba(255, 255, 255, 0.3);
+  text-underline-offset: 0.15rem;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.log-card-ref:hover {
+  text-decoration-color: currentColor;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.3);
+}
+
+.log-card-ref:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.log-card-ref.card-type-creature.card-color-red {
+  color: #f97316;
+}
+
+.log-card-ref.card-type-spell.card-color-red {
+  color: #fb7185;
+}
+
+.log-card-ref.card-type-creature.card-color-blue {
+  color: #38bdf8;
+}
+
+.log-card-ref.card-type-spell.card-color-blue {
+  color: #93c5fd;
+}
+
+.log-card-ref.card-type-creature.card-color-green {
+  color: #34d399;
+}
+
+.log-card-ref.card-type-spell.card-color-green {
+  color: #a7f3d0;
+}
+
+.log-card-ref.card-color-neutral {
+  color: #fbbf24;
+}
+
+.log-value {
+  font-weight: 700;
+}
+
+.log-value.damage {
+  color: #ef4444;
+}
+
+.log-value.heal {
+  color: #a3e635;
+}
+
+.log-keyword {
+  color: #facc15;
+  font-weight: 600;
 }
 
 .log-dropdown {
@@ -205,15 +315,15 @@ input {
 }
 
 .log-dropdown.open {
-  max-height: 180px;
+  max-height: 220px;
 }
 
 .log-scroll {
-  max-height: 160px;
+  max-height: 200px;
   overflow-y: auto;
   padding-right: 0.3rem;
-  font-size: 0.75rem;
-  line-height: 1.4;
+  font-size: 0.82rem;
+  line-height: 1.5;
 }
 
 .battlefield-area {
@@ -242,15 +352,20 @@ input {
 }
 
 .battlefield {
-  min-height: 92px;
+  min-height: 140px;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  gap: 0.6rem;
+  align-content: start;
 }
 
 .placeholder {
   margin: 0;
   color: rgba(255, 255, 255, 0.45);
+  grid-column: 1 / -1;
+  text-align: center;
+  padding: 1.2rem 0;
 }
 
 .card {
@@ -262,6 +377,52 @@ input {
   gap: 0.4rem;
   border: 1px solid rgba(255, 255, 255, 0.08);
   font-size: 0.85rem;
+}
+
+.battlefield .card {
+  height: 100%;
+}
+
+.card.card-color-red.creature-card {
+  background: linear-gradient(140deg, rgba(58, 13, 20, 0.92), rgba(138, 40, 24, 0.78));
+  border-color: rgba(249, 115, 22, 0.45);
+  box-shadow: 0 8px 16px rgba(249, 115, 22, 0.2);
+}
+
+.card.card-color-red.spell-card {
+  background: linear-gradient(140deg, rgba(76, 17, 32, 0.85), rgba(177, 64, 46, 0.72));
+  border-color: rgba(251, 146, 60, 0.45);
+  box-shadow: 0 6px 14px rgba(251, 146, 60, 0.18);
+}
+
+.card.card-color-blue.creature-card {
+  background: linear-gradient(140deg, rgba(16, 35, 66, 0.92), rgba(27, 76, 125, 0.78));
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: 0 8px 16px rgba(96, 165, 250, 0.18);
+}
+
+.card.card-color-blue.spell-card {
+  background: linear-gradient(140deg, rgba(25, 52, 92, 0.88), rgba(47, 110, 170, 0.7));
+  border-color: rgba(147, 197, 253, 0.4);
+  box-shadow: 0 6px 14px rgba(147, 197, 253, 0.16);
+}
+
+.card.card-color-green.creature-card {
+  background: linear-gradient(140deg, rgba(16, 52, 41, 0.92), rgba(25, 95, 63, 0.78));
+  border-color: rgba(52, 211, 153, 0.45);
+  box-shadow: 0 8px 16px rgba(52, 211, 153, 0.2);
+}
+
+.card.card-color-green.spell-card {
+  background: linear-gradient(140deg, rgba(24, 73, 54, 0.85), rgba(45, 125, 84, 0.7));
+  border-color: rgba(110, 231, 183, 0.4);
+  box-shadow: 0 6px 14px rgba(110, 231, 183, 0.18);
+}
+
+.card.card-color-neutral {
+  background: linear-gradient(140deg, rgba(34, 40, 70, 0.9), rgba(18, 22, 38, 0.82));
+  border-color: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 6px 14px rgba(148, 163, 184, 0.18);
 }
 
 .card.playable {
@@ -356,9 +517,9 @@ input {
 }
 
 .mini {
-  font-size: 0.65rem;
-  padding: 0.35rem 0.5rem;
-  background: rgba(255, 255, 255, 0.1);
+  font-size: 0.8rem;
+  padding: 0.4rem 0.65rem;
+  background: rgba(255, 255, 255, 0.12);
   border-radius: 8px;
   width: auto;
 }
@@ -385,8 +546,8 @@ input {
 
 .hand-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
-  gap: 0.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 0.75rem;
 }
 
 .status-bar {
@@ -396,6 +557,95 @@ input {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
+}
+
+.card-preview-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 8, 18, 0.78);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(1rem, 5vw, 3rem);
+  z-index: 1000;
+}
+
+.card-preview-dialog {
+  position: relative;
+  max-width: min(380px, 90vw);
+}
+
+.card.preview-card {
+  width: min(340px, 85vw);
+  font-size: 0.95rem;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.55);
+}
+
+.card.preview-card .card-body {
+  font-size: 0.85rem;
+}
+
+.preview-close {
+  position: absolute;
+  top: -0.75rem;
+  right: -0.75rem;
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(11, 15, 28, 0.9);
+  color: #fff;
+  font-size: 1.2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.preview-close:hover {
+  transform: scale(1.05);
+  background: rgba(31, 41, 81, 0.95);
+}
+
+.card-preview-missing {
+  margin: 2rem 0 1rem;
+  text-align: center;
+  color: #d4dcff;
+}
+
+@media (max-width: 600px) {
+  .battlefield {
+    min-height: 120px;
+    gap: 0.45rem;
+  }
+
+  .hand-cards {
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  }
+}
+
+@media (min-width: 900px) {
+  .status-bar {
+    flex-direction: row;
+    align-items: center;
+    gap: 1rem;
+  }
+
+  .status-bar > * {
+    flex: 1;
+  }
+
+  .phase-controls {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+
+  .phase-controls button {
+    width: auto;
+    min-width: 140px;
+  }
 }
 
 .life-summary,


### PR DESCRIPTION
## Summary
- make the game view stretch to the full viewport, refine battlefield grid spacing, and adjust hand layout
- color-code cards and battle log entries by faction/type while showing five recent events
- allow clicking log entries to open a styled modal preview and emit structured log segments across the rules engine

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d320860a10832abb87252147e8f465