### PR TITLE
Split battle and spell logs with an active spell slot

### DIFF
--- a/src/app/game/ai.js
+++ b/src/app/game/ai.js
@@ -114,7 +114,7 @@ function aiPlayTurnStep(aiPlayer) {
     scheduleAI(() => {
       helpers.removeFromHand(aiPlayer, card.instanceId);
       helpers.spendMana(aiPlayer, card.cost ?? 0);
-      addLog([playerSegment(aiPlayer), textSegment(' casts '), cardSegment(card), textSegment('.')]);
+      addLog([playerSegment(aiPlayer), textSegment(' casts '), cardSegment(card), textSegment('.')], undefined, 'spell');
       const pending = {
         controller: 1,
         card,

--- a/src/app/game/core.js
+++ b/src/app/game/core.js
@@ -131,7 +131,7 @@ export function playCreature(playerIndex, card) {
   card.damageMarked = 0;
   card.buffs = [];
   player.battlefield.push(card);
-  addLog([playerSegment(player), textSegment(' summons '), cardSegment(card), textSegment('.')]);
+  addLog([playerSegment(player), textSegment(' summons '), cardSegment(card), textSegment('.')], undefined, 'spell');
   handlePassive(card, playerIndex, 'onEnter');
 }
 
@@ -150,7 +150,7 @@ export function prepareSpell(playerIndex, card) {
     chosenTargets: {},
     cancellable: true,
   };
-  addLog([playerSegment(player), textSegment(' prepares '), cardSegment(card), textSegment('.')]);
+  addLog([playerSegment(player), textSegment(' prepares '), cardSegment(card), textSegment('.')], undefined, 'spell');
   if (requirements.length === 0) {
     executeSpell(game.pendingAction);
   } else {
@@ -272,7 +272,7 @@ export function cancelPendingAction() {
   const { pendingAction } = game;
   game.pendingAction = null;
   if (pendingAction.type === 'spell') {
-    addLog([cardSegment(pendingAction.card), textSegment(' cancelled.')]);
+    addLog([cardSegment(pendingAction.card), textSegment(' cancelled.')], undefined, 'spell');
   } else if (pendingAction.card) {
     addLog([cardSegment(pendingAction.card), textSegment(' action cancelled.')]);
   } else {
@@ -286,7 +286,7 @@ export function executeSpell(pending) {
   const player = game.players[pending.controller];
   removeFromHand(player, pending.card.instanceId);
   spendMana(player, pending.card.cost ?? 0);
-  addLog([playerSegment(player), textSegment(' casts '), cardSegment(pending.card), textSegment('.')]);
+  addLog([playerSegment(player), textSegment(' casts '), cardSegment(pending.card), textSegment('.')], undefined, 'spell');
   resolveEffects(pending.effects, pending);
   player.graveyard.push(pending.card);
   game.pendingAction = null;
@@ -633,7 +633,7 @@ export function handlePassive(card, controllerIndex, trigger) {
 
   if (effect.type === 'damage' && effect.target === 'any') {
     if (description) {
-      addLog([cardSegment(card), textSegment(' triggers: '), textSegment(description)]);
+      addLog([cardSegment(card), textSegment(' triggers: '), textSegment(description)], undefined, 'spell');
     }
     const requirements = buildEffectRequirements([effect]);
     if (requirements.length) {
@@ -655,7 +655,7 @@ export function handlePassive(card, controllerIndex, trigger) {
   }
 
   if (description) {
-    addLog([cardSegment(card), textSegment(' triggers: '), textSegment(description)]);
+    addLog([cardSegment(card), textSegment(' triggers: '), textSegment(description)], undefined, 'spell');
   }
 
   const requiresChoice = effectRequiresChoice(effect);
@@ -848,7 +848,8 @@ export function startGame(color) {
   game.currentPlayer = game.dice.winner;
   state.game = game;
   state.screen = 'game';
-  state.ui.logExpanded = false;
+  state.ui.battleLogExpanded = false;
+  state.ui.spellLogExpanded = false;
   state.ui.previewCard = null;
   addLog(
     `Initiative roll — You: ${game.dice.player}, AI: ${game.dice.ai}. ${game.currentPlayer === 0 ? 'You go first.' : 'AI goes first.'}`,

--- a/src/app/state.js
+++ b/src/app/state.js
@@ -15,7 +15,8 @@ export const initialState = {
   },
   game: null,
   ui: {
-    logExpanded: false,
+    battleLogExpanded: false,
+    spellLogExpanded: false,
     previewCard: null,
   },
 };

--- a/src/app/ui/events.js
+++ b/src/app/ui/events.js
@@ -62,13 +62,19 @@ export function attachEventHandlers(root) {
     });
   }
 
-  const toggleLogBtn = root.querySelector('[data-action="toggle-log"]');
-  if (toggleLogBtn) {
-    toggleLogBtn.addEventListener('click', () => {
-      state.ui.logExpanded = !state.ui.logExpanded;
+  root.querySelectorAll('[data-action="toggle-battle-log"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      state.ui.battleLogExpanded = !state.ui.battleLogExpanded;
       requestRender();
     });
-  }
+  });
+
+  root.querySelectorAll('[data-action="toggle-spell-log"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      state.ui.spellLogExpanded = !state.ui.spellLogExpanded;
+      requestRender();
+    });
+  });
 
   const emailForm = root.querySelector('#email-form');
   if (emailForm) {

--- a/src/style.css
+++ b/src/style.css
@@ -182,48 +182,197 @@ input {
   gap: 0.75rem;
 }
 
+.top-status-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+@media (min-width: 1080px) {
+  .top-status-grid {
+    grid-template-columns: minmax(260px, 1fr) minmax(320px, 1.2fr) minmax(260px, 1fr);
+    align-items: stretch;
+  }
+}
+
 .log-panel {
   background: rgba(15, 18, 32, 0.82);
   border-radius: 16px;
-  padding: 0.6rem 0.8rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  padding: 0.8rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  min-height: 120px;
+  gap: 0.65rem;
+  min-height: 180px;
 }
 
-.log-header {
+.log-header,
+.panel-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 0.5rem;
 }
 
-.log-recent,
-.log-dropdown ul {
+.log-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  max-height: 150px;
+  transition: max-height 0.25s ease;
+}
+
+.log-scroll.expanded {
+  max-height: 260px;
+}
+
+.log-scroll ul {
   margin: 0;
   padding-left: 0;
   list-style: none;
-  font-size: 0.82rem;
-  line-height: 1.5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.log-recent li,
-.log-dropdown li {
+.log-scroll li {
   color: #e5e8ff;
 }
 
-.log-recent,
-.log-dropdown ul {
-  display: flex;
-  flex-direction: column;
-  gap: 0.3rem;
+.log-placeholder {
+  opacity: 0.25;
 }
 
-.log-recent {
+.log-empty {
+  color: rgba(229, 232, 255, 0.7);
+  text-align: center;
+  padding: 0.4rem 0;
+}
+
+.active-spell-panel {
+  background: rgba(15, 18, 32, 0.88);
+  border-radius: 16px;
+  padding: 0.9rem 1.1rem;
+  box-shadow: inset 0 0 0 1px rgba(86, 110, 255, 0.18), 0 12px 28px rgba(0, 0, 0, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  min-height: 180px;
+  position: relative;
+}
+
+.active-spell-panel.empty {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 12px 28px rgba(0, 0, 0, 0.32);
+}
+
+.panel-status {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #d6ddff;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.2rem 0.65rem;
+}
+
+.panel-status.idle {
+  color: rgba(214, 221, 255, 0.6);
+}
+
+.active-spell-body {
+  background: rgba(23, 29, 50, 0.72);
+  border-radius: 14px;
+  padding: 0.85rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-height: 120px;
+}
+
+.active-spell-body.card-color-red {
+  border-color: rgba(249, 115, 22, 0.45);
+  box-shadow: inset 0 0 18px rgba(249, 115, 22, 0.18);
+}
+
+.active-spell-body.card-color-blue {
+  border-color: rgba(96, 165, 250, 0.45);
+  box-shadow: inset 0 0 18px rgba(96, 165, 250, 0.18);
+}
+
+.active-spell-body.card-color-green {
+  border-color: rgba(52, 211, 153, 0.45);
+  box-shadow: inset 0 0 18px rgba(52, 211, 153, 0.18);
+}
+
+.active-spell-body.card-color-neutral {
+  border-color: rgba(251, 191, 36, 0.45);
+  box-shadow: inset 0 0 18px rgba(251, 191, 36, 0.15);
+}
+
+.active-card-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.active-card-title .cost {
+  font-size: 0.75rem;
+  color: #c8d0ff;
+  font-variant-numeric: tabular-nums;
+}
+
+.active-card-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.72rem;
+  color: rgba(214, 221, 255, 0.75);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.active-card-text {
+  margin: 0;
+  font-size: 0.78rem;
+  color: #d5ddff;
+}
+
+.active-placeholder-text {
+  margin: 0;
+  font-size: 0.78rem;
+  color: rgba(214, 221, 255, 0.65);
+}
+
+.active-instructions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.78rem;
+  color: #dbe2ff;
+}
+
+.active-instructions p {
+  margin: 0;
   flex: 1;
-  overflow-y: auto;
-  min-height: 60px;
+}
+
+.target-progress {
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #c4f1ff;
+}
+
+.active-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .log-player {
@@ -309,24 +458,6 @@ input {
 .log-keyword {
   color: #facc15;
   font-weight: 600;
-}
-
-.log-dropdown {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.25s ease;
-}
-
-.log-dropdown.open {
-  max-height: 220px;
-}
-
-.log-scroll {
-  max-height: 200px;
-  overflow-y: auto;
-  padding-right: 0.3rem;
-  font-size: 0.82rem;
-  line-height: 1.5;
 }
 
 .battlefield-area {


### PR DESCRIPTION
## Summary
- categorize log entries so battle and spell events can be rendered separately
- redesign the top of the game view with dedicated battle and spell log panels around a new active spell slot display
- hook up new UI controls, styling, and log entries for spells and creatures to feed the spell log

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d401740a84832aa262ccb8f49c4e27