### PR TITLE
Add active spell targeting flow with player targeting support

### DIFF
--- a/src/app/game/interactions.js
+++ b/src/app/game/interactions.js
@@ -3,7 +3,9 @@ import { addLog } from './log.js';
 import {
   activateCreatureAbility,
   canPlayCard,
+  handlePlayerTargetSelection,
   handleTargetSelection,
+  isTargetablePlayer,
   playCreature,
   prepareSpell,
 } from './core.js';
@@ -59,3 +61,12 @@ export function handleCreatureClick(cardId, controller) {
 }
 
 export { activateCreatureAbility };
+
+export function handleLifeOrbClick(playerIndex) {
+  const game = state.game;
+  if (!game?.pendingAction) return;
+  if (!isTargetablePlayer(playerIndex, game.pendingAction)) {
+    return;
+  }
+  handlePlayerTargetSelection(playerIndex);
+}

--- a/src/style.css
+++ b/src/style.css
@@ -621,6 +621,11 @@ input {
   border-color: #c084fc;
 }
 
+.card.targeted {
+  border-color: #38bdf8;
+  box-shadow: 0 0 18px rgba(56, 189, 248, 0.6);
+}
+
 .creature-card.summoning {
   opacity: 0.7;
 }
@@ -1002,6 +1007,18 @@ button.disabled {
   animation: pulse-danger 2s ease-in-out infinite;
 }
 
+.life-orb.targetable {
+  cursor: pointer;
+  border-color: #38bdf8;
+  box-shadow: inset 0 0 18px rgba(56, 189, 248, 0.35), 0 0 18px rgba(56, 189, 248, 0.4);
+}
+
+.life-orb.targeted {
+  border-color: #0ea5e9;
+  box-shadow: inset 0 0 24px rgba(14, 165, 233, 0.6), 0 0 24px rgba(14, 165, 233, 0.6);
+  cursor: pointer;
+}
+
 @keyframes pulse-danger {
   0%, 100% {
     box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5), 0 0 15px rgba(239, 68, 68, 0.5);
@@ -1228,6 +1245,30 @@ button.disabled {
   stroke: #f97316;
   marker-end: url(#arrow-orange);
   filter: drop-shadow(0 0 6px rgba(249, 115, 22, 0.75));
+}
+
+.target-lines-svg {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 16;
+}
+
+.target-line {
+  stroke: #38bdf8;
+  stroke-width: 3px;
+  stroke-linecap: round;
+  filter: drop-shadow(0 0 6px rgba(56, 189, 248, 0.75));
+}
+
+.target-line.preview {
+  stroke-dasharray: 6 6;
+  opacity: 0.7;
+}
+
+.target-line.confirmed {
+  stroke: #0ea5e9;
+  filter: drop-shadow(0 0 10px rgba(14, 165, 233, 0.8));
 }
 
 @keyframes attack-line-appear {


### PR DESCRIPTION
## Summary
- route all spells and targeted on-enter abilities through a pending action that captures targets, supports player targets, and requires a final confirmation before resolving
- highlight creatures and life orbs as valid/selected targets, draw blue target indicator lines from the active spell panel, and make life totals clickable for damage-or-any-target effects
- pace AI spell casting and targeted summons through the same active spell slot flow so target previews and confirmations are visible to the player

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40b42f27c832aa659853f2abcf047