### PR TITLE
Add animated battlefield skins and crevice divider

### DIFF
--- a/src/app/ui/views/battlefield/blueField.js
+++ b/src/app/ui/views/battlefield/blueField.js
@@ -1,0 +1,9 @@
+export function renderBlueFieldSkin() {
+  return `
+    <div class="battlefield-skin battlefield-skin-blue">
+      <div class="texture-layer tide-flow"></div>
+      <div class="texture-layer foam-crests"></div>
+      <div class="texture-layer mist-haze"></div>
+    </div>
+  `;
+}

--- a/src/app/ui/views/battlefield/greenField.js
+++ b/src/app/ui/views/battlefield/greenField.js
@@ -1,0 +1,9 @@
+export function renderGreenFieldSkin() {
+  return `
+    <div class="battlefield-skin battlefield-skin-green">
+      <div class="texture-layer canopy-sway"></div>
+      <div class="texture-layer pollen-drift"></div>
+      <div class="texture-layer sunbeams"></div>
+    </div>
+  `;
+}

--- a/src/app/ui/views/battlefield/index.js
+++ b/src/app/ui/views/battlefield/index.js
@@ -1,0 +1,22 @@
+import { renderRedFieldSkin } from './redField.js';
+import { renderBlueFieldSkin } from './blueField.js';
+import { renderGreenFieldSkin } from './greenField.js';
+import { renderNeutralFieldSkin } from './neutralField.js';
+
+const RENDERERS = {
+  red: renderRedFieldSkin,
+  blue: renderBlueFieldSkin,
+  green: renderGreenFieldSkin,
+  neutral: renderNeutralFieldSkin,
+};
+
+export function renderBattlefieldSkin(color, { isOpponent = false } = {}) {
+  const key = String(color || 'neutral').toLowerCase();
+  const renderer = RENDERERS[key] || renderNeutralFieldSkin;
+  const skinMarkup = renderer();
+  const orientationClass = isOpponent ? 'skin-opponent' : 'skin-player';
+  return skinMarkup.replace(
+    'battlefield-skin ',
+    `battlefield-skin ${orientationClass} `,
+  );
+}

--- a/src/app/ui/views/battlefield/neutralField.js
+++ b/src/app/ui/views/battlefield/neutralField.js
@@ -1,0 +1,8 @@
+export function renderNeutralFieldSkin() {
+  return `
+    <div class="battlefield-skin battlefield-skin-neutral">
+      <div class="texture-layer ether-waves"></div>
+      <div class="texture-layer starfall"></div>
+    </div>
+  `;
+}

--- a/src/app/ui/views/battlefield/redField.js
+++ b/src/app/ui/views/battlefield/redField.js
@@ -1,0 +1,9 @@
+export function renderRedFieldSkin() {
+  return `
+    <div class="battlefield-skin battlefield-skin-red">
+      <div class="texture-layer lava-current"></div>
+      <div class="texture-layer ember-sparks"></div>
+      <div class="texture-layer heat-haze"></div>
+    </div>
+  `;
+}

--- a/src/app/ui/views/gameView.js
+++ b/src/app/ui/views/gameView.js
@@ -10,6 +10,7 @@ import {
   canPlayCard,
 } from '../../game/core.js';
 import { getCreatureStats, hasShimmer } from '../../game/creatures.js';
+import { renderBattlefieldSkin } from './battlefield/index.js';
 
 function getCardColorClass(card) {
   return `card-color-${card?.color ?? 'neutral'}`;
@@ -149,6 +150,7 @@ ${renderPlayerStatBar(opponent, game, true)}
         <div class="battle-row opponent-row">
           ${renderPlayerBoard(opponent, game, true)}
         </div>
+        ${renderBattlefieldCrevice()}
         <div class="battle-row player-row">
           ${renderPlayerBoard(player, game, false)}
         </div>
@@ -367,11 +369,23 @@ function renderPlayerStatBar(player, game, isOpponent) {
   `;
 }
 
+function renderBattlefieldCrevice() {
+  return `
+    <div class="battlefield-crevice">
+      <div class="crevice-surface"></div>
+      <div class="crevice-fissures"></div>
+    </div>
+  `;
+}
+
 function renderPlayerBoard(player, game, isOpponent) {
   const creatures = player.battlefield.filter((c) => c.type === 'creature');
   const playerIndex = game.players.indexOf(player);
+  const colorClass = sanitizeClass(player.color || 'neutral');
+  const skin = renderBattlefieldSkin(player.color, { isOpponent });
   return `
-    <div class="board" data-player="${playerIndex}">
+    <div class="board player-battlefield player-color-${colorClass}" data-player="${playerIndex}">
+      ${skin}
       <div class="battlefield">
         ${
           creatures.length

--- a/src/style.css
+++ b/src/style.css
@@ -474,18 +474,363 @@ input {
 }
 
 .battlefield-area {
-  background: linear-gradient(180deg, rgba(61, 47, 31, 0.2), rgba(40, 33, 26, 0.35));
-  border-radius: 16px;
-  padding: 0.6rem 0.75rem;
+  position: relative;
+  background: radial-gradient(circle at 50% 0%, rgba(41, 29, 18, 0.32), rgba(9, 9, 16, 0.78));
+  border-radius: 18px;
+  padding: 0.9rem 1.1rem;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), inset 0 -30px 60px rgba(0, 0, 0, 0.2);
+  gap: 0.8rem;
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.05),
+    inset 0 -30px 60px rgba(0, 0, 0, 0.22),
+    0 18px 36px rgba(0, 0, 0, 0.35);
+  overflow: hidden;
 }
 
 .battle-row {
   display: flex;
   flex-direction: column;
+}
+
+.battlefield-crevice {
+  position: relative;
+  height: clamp(18px, 2.6vw, 28px);
+  display: flex;
+  align-items: stretch;
+  justify-content: center;
+  overflow: visible;
+}
+
+.battlefield-crevice::before,
+.battlefield-crevice::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  width: 46%;
+  height: 100%;
+  background: linear-gradient(180deg, rgba(249, 115, 22, 0.12), rgba(30, 64, 175, 0));
+  mix-blend-mode: screen;
+  opacity: 0.35;
+  filter: blur(1.5px);
+}
+
+.battlefield-crevice::before {
+  left: 0;
+  transform: skewX(-6deg);
+}
+
+.battlefield-crevice::after {
+  right: 0;
+  transform: skewX(6deg);
+}
+
+.battlefield-crevice .crevice-surface {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(44, 23, 19, 0.92), rgba(10, 6, 4, 0.95));
+  clip-path: polygon(0% 15%, 8% 0%, 18% 10%, 34% 2%, 52% 12%, 68% 4%, 82% 14%, 92% 2%, 100% 18%, 100% 100%, 0% 100%);
+  box-shadow: inset 0 0 12px rgba(0, 0, 0, 0.45), 0 18px 22px rgba(0, 0, 0, 0.45);
+}
+
+.battlefield-crevice .crevice-fissures {
+  position: absolute;
+  inset: 4px 10%;
+  background:
+    repeating-linear-gradient(120deg, rgba(0, 0, 0, 0.65) 0 6px, transparent 6px 12px),
+    repeating-linear-gradient(60deg, rgba(88, 28, 135, 0.08) 0 10px, transparent 10px 18px);
+  opacity: 0.7;
+  mask: radial-gradient(ellipse at center, rgba(255, 255, 255, 0.95) 0%, rgba(255, 255, 255, 0) 82%);
+  animation: fissureGlow 9s ease-in-out infinite;
+}
+
+@keyframes fissureGlow {
+  0%,
+  100% {
+    opacity: 0.55;
+    filter: saturate(1);
+  }
+  50% {
+    opacity: 0.85;
+    filter: saturate(1.4);
+  }
+}
+
+.player-battlefield {
+  position: relative;
+  border-radius: 18px;
+  overflow: hidden;
+  background: rgba(12, 16, 24, 0.76);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 14px 28px rgba(0, 0, 0, 0.32);
+  min-height: clamp(160px, 28vh, 240px);
+}
+
+.player-battlefield.player-color-red {
+  box-shadow:
+    inset 0 0 0 1px rgba(249, 115, 22, 0.22),
+    0 18px 42px rgba(127, 29, 29, 0.32);
+}
+
+.player-battlefield.player-color-blue {
+  box-shadow:
+    inset 0 0 0 1px rgba(96, 165, 250, 0.2),
+    0 18px 42px rgba(30, 64, 175, 0.28);
+}
+
+.player-battlefield.player-color-green {
+  box-shadow:
+    inset 0 0 0 1px rgba(52, 211, 153, 0.24),
+    0 18px 42px rgba(6, 95, 70, 0.28);
+}
+
+.player-battlefield.player-color-neutral {
+  box-shadow:
+    inset 0 0 0 1px rgba(226, 232, 240, 0.12),
+    0 18px 42px rgba(15, 23, 42, 0.32);
+}
+
+.battlefield-skin {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+  overflow: hidden;
+  transform-origin: center;
+}
+
+.battlefield-skin.skin-opponent {
+  transform: scaleY(-1);
+  filter: saturate(0.95) brightness(0.92);
+}
+
+.battlefield-skin .texture-layer {
+  position: absolute;
+  inset: 0;
+  background-repeat: repeat;
+  mix-blend-mode: screen;
+}
+
+.battlefield-skin .texture-layer:first-child {
+  mix-blend-mode: normal;
+}
+
+.battlefield-skin-red .lava-current {
+  background:
+    radial-gradient(circle at 18% 22%, rgba(248, 113, 113, 0.45), transparent 55%),
+    radial-gradient(circle at 72% 18%, rgba(251, 191, 36, 0.42), transparent 60%),
+    radial-gradient(circle at 56% 82%, rgba(239, 68, 68, 0.4), transparent 60%),
+    linear-gradient(145deg, rgba(61, 16, 16, 0.92), rgba(17, 8, 6, 0.94));
+  background-size: 160% 160%;
+  animation: lavaFlow 18s linear infinite;
+}
+
+.battlefield-skin-red .ember-sparks {
+  background-image:
+    radial-gradient(rgba(251, 146, 60, 0.8) 0 2px, transparent 2px),
+    radial-gradient(rgba(248, 113, 113, 0.6) 0 1.5px, transparent 1.5px);
+  background-size: 120px 120px, 80px 80px;
+  opacity: 0.55;
+  animation: emberDrift 12s linear infinite;
+}
+
+.battlefield-skin-red .heat-haze {
+  background: radial-gradient(circle at 50% 40%, rgba(255, 244, 214, 0.25), transparent 68%);
+  filter: blur(28px);
+  opacity: 0.32;
+  animation: heatPulse 9s ease-in-out infinite;
+}
+
+.battlefield-skin-blue .tide-flow {
+  background:
+    radial-gradient(circle at 20% 30%, rgba(56, 189, 248, 0.35), transparent 60%),
+    radial-gradient(circle at 78% 22%, rgba(37, 99, 235, 0.45), transparent 65%),
+    linear-gradient(160deg, rgba(11, 33, 68, 0.92), rgba(4, 13, 28, 0.95));
+  background-size: 170% 170%;
+  animation: tidePulse 22s ease-in-out infinite;
+}
+
+.battlefield-skin-blue .foam-crests {
+  background-image:
+    repeating-linear-gradient(
+      135deg,
+      rgba(191, 219, 254, 0.5) 0,
+      rgba(191, 219, 254, 0.5) 4px,
+      transparent 4px,
+      transparent 14px
+    );
+  background-size: 220px 220px;
+  opacity: 0.45;
+  animation: foamDrift 16s linear infinite;
+}
+
+.battlefield-skin-blue .mist-haze {
+  background: radial-gradient(circle at 60% 70%, rgba(191, 219, 254, 0.25), transparent 70%);
+  filter: blur(32px);
+  opacity: 0.35;
+  animation: mistRise 14s ease-in-out infinite;
+}
+
+.battlefield-skin-green .canopy-sway {
+  background:
+    radial-gradient(circle at 18% 30%, rgba(134, 239, 172, 0.4), transparent 60%),
+    radial-gradient(circle at 74% 22%, rgba(52, 211, 153, 0.45), transparent 60%),
+    linear-gradient(150deg, rgba(12, 41, 32, 0.95), rgba(7, 20, 14, 0.92));
+  background-size: 180% 160%;
+  animation: canopyDrift 24s linear infinite;
+}
+
+.battlefield-skin-green .pollen-drift {
+  background-image:
+    radial-gradient(rgba(187, 247, 208, 0.75) 0 1.8px, transparent 1.8px),
+    radial-gradient(rgba(74, 222, 128, 0.6) 0 1.2px, transparent 1.2px);
+  background-size: 140px 140px, 90px 90px;
+  opacity: 0.5;
+  animation: pollenFloat 18s linear infinite;
+}
+
+.battlefield-skin-green .sunbeams {
+  background: conic-gradient(from 120deg, rgba(34, 197, 94, 0.12), rgba(134, 239, 172, 0.05), rgba(15, 118, 110, 0.18), transparent 70%);
+  filter: blur(24px);
+  opacity: 0.28;
+  animation: sunbeamPulse 12s ease-in-out infinite;
+}
+
+.battlefield-skin-neutral .ether-waves {
+  background:
+    radial-gradient(circle at 15% 25%, rgba(148, 163, 184, 0.36), transparent 58%),
+    radial-gradient(circle at 78% 22%, rgba(125, 211, 252, 0.32), transparent 65%),
+    linear-gradient(145deg, rgba(23, 37, 84, 0.92), rgba(8, 11, 23, 0.94));
+  background-size: 180% 180%;
+  animation: etherFlow 26s linear infinite;
+}
+
+.battlefield-skin-neutral .starfall {
+  background-image: radial-gradient(rgba(191, 219, 254, 0.8) 0 1.2px, transparent 1.2px);
+  background-size: 120px 120px;
+  opacity: 0.35;
+  animation: starfallDrift 28s linear infinite;
+}
+
+@keyframes lavaFlow {
+  0% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 80% 100%;
+  }
+  100% {
+    background-position: 160% 0%;
+  }
+}
+
+@keyframes emberDrift {
+  0% {
+    background-position: 0 0, 0 0;
+  }
+  100% {
+    background-position: 120px 240px, -80px 160px;
+  }
+}
+
+@keyframes heatPulse {
+  0%,
+  100% {
+    opacity: 0.24;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.36;
+    transform: scale(1.06);
+  }
+}
+
+@keyframes tidePulse {
+  0% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 100% 80%;
+  }
+  100% {
+    background-position: 200% 10%;
+  }
+}
+
+@keyframes foamDrift {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: 220px 180px;
+  }
+}
+
+@keyframes mistRise {
+  0%,
+  100% {
+    opacity: 0.28;
+    transform: translateY(0);
+  }
+  50% {
+    opacity: 0.4;
+    transform: translateY(-6%);
+  }
+}
+
+@keyframes canopyDrift {
+  0% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 70% 90%;
+  }
+  100% {
+    background-position: 160% 0%;
+  }
+}
+
+@keyframes pollenFloat {
+  0% {
+    background-position: 0 0, 0 0;
+  }
+  100% {
+    background-position: -140px 160px, 90px 200px;
+  }
+}
+
+@keyframes sunbeamPulse {
+  0%,
+  100% {
+    opacity: 0.18;
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    opacity: 0.32;
+    transform: rotate(4deg) scale(1.04);
+  }
+}
+
+@keyframes etherFlow {
+  0% {
+    background-position: 0% 0%;
+  }
+  50% {
+    background-position: 90% 80%;
+  }
+  100% {
+    background-position: 180% 0%;
+  }
+}
+
+@keyframes starfallDrift {
+  0% {
+    background-position: 0 0;
+  }
+  100% {
+    background-position: -120px 160px;
+  }
 }
 
 .player-header {
@@ -500,12 +845,15 @@ input {
 }
 
 .battlefield {
+  position: relative;
+  z-index: 2;
   min-height: 140px;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-auto-rows: 1fr;
   gap: 0.6rem;
   align-content: start;
+  padding: clamp(0.7rem, 1.2vw, 1.05rem);
 }
 
 .placeholder {


### PR DESCRIPTION
## Summary
- add dedicated battlefield skin renderers for red, blue, green, and neutral territories
- integrate animated territory skins and a shattered crevice divider into the game view
- style the battlefield with animated gradients and faction-specific glows for each side

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d43056419c832a81f24a9311bfb5cf