### PR TITLE
Add combat trigger stage and surface triggered ability previews

### DIFF
--- a/src/app/game/ai.js
+++ b/src/app/game/ai.js
@@ -1,6 +1,6 @@
 import { state, requestRender } from '../state.js';
 import { addLog, cardSegment, playerSegment, textSegment } from './log.js';
-import { resolveCombat, skipCombat, triggerAttackPassive } from './combat.js';
+import { confirmAttackers, skipCombat } from './combat.js';
 import { getCreatureStats } from './creatures.js';
 
 let helpers = {
@@ -196,7 +196,7 @@ function aiDeclareAttacks() {
   }
   // Declare after a delay (this function itself is usually called via scheduleAI, but be robust)
   game.combat.attackers = attackers.map((creature) => ({ creature, controller: 1 }));
-  game.combat.stage = 'blockers';
+  game.combat.stage = 'choose';
   attackers.forEach((creature) => {
     helpers.addLog([
       playerSegment(game.players[1]),
@@ -204,25 +204,7 @@ function aiDeclareAttacks() {
       cardSegment(creature),
       textSegment(' into battle.'),
     ]);
-    triggerAttackPassive(creature, 1);
   });
-  game.blocking = {
-    attackers: [...game.combat.attackers],
-    assignments: {},
-    selectedBlocker: null,
-    awaitingDefender: false,
-  };
-  const blockers = game.players[0].battlefield.filter((c) => c.type === 'creature');
-  if (blockers.length === 0) {
-    addLog([playerSegment(game.players[0]), textSegment(' has no blockers.')]);
-    // Show attack indicators for a moment, then resolve combat
-    requestRender();
-    scheduleAI(() => {
-      resolveCombat();
-      runAI();
-    });
-    return;
-  }
-  game.blocking.awaitingDefender = true;
   requestRender();
+  confirmAttackers();
 }

--- a/src/app/ui/views/graveyardView.js
+++ b/src/app/ui/views/graveyardView.js
@@ -27,6 +27,9 @@ export function renderGraveyardModal(game) {
           if (card.activated) {
             bodyParts.push(`<p class="card-ability-preview">${escapeHtml(card.activated.name || 'Ability')}: ${escapeHtml(card.activated.description)}</p>`);
           }
+          if (card.passive?.type === 'onAttack') {
+            bodyParts.push(`<p class="card-triggered-preview">Triggered — ${escapeHtml(card.passive.description)}</p>`);
+          }
           const body = bodyParts.join('');
           return `
             <article class="card ${typeClass} ${colorClass}">

--- a/src/style.css
+++ b/src/style.css
@@ -1270,6 +1270,13 @@ input {
   font-style: italic;
 }
 
+.card-triggered-preview {
+  font-size: 0.68rem;
+  color: #f6ad55;
+  margin: 0.2rem 0 0 0;
+  font-style: italic;
+}
+
 .ability-button .mana-gem.small {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
## Summary
- add a dedicated combat trigger stage that resolves on-attack passives with the same targeting UX as activated abilities
- ensure both players and AI step through each trigger sequentially before blockers and reuse confirm/cancel flows
- surface triggered ability previews on cards in hand, graveyard, and previews using orange styling for clarity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4842d5ae8832a91e5d44227a35a6a