### PR TITLE
Improve optional Nature's Herald trigger UX

### DIFF
--- a/src/app/game/core/flow.js
+++ b/src/app/game/core/flow.js
@@ -170,6 +170,7 @@ export function handlePassive(card, controllerIndex, trigger) {
   const description = card.passive.description;
   const opponentIndex = controllerIndex === 0 ? 1 : 0;
   const player = state.game.players[controllerIndex];
+  const isOptional = effect.optional === true;
 
   const pending = {
     type: 'trigger',
@@ -180,7 +181,8 @@ export function handlePassive(card, controllerIndex, trigger) {
     requirementIndex: 0,
     selectedTargets: [],
     chosenTargets: {},
-    cancellable: false,
+    cancellable: isOptional ? true : false,
+    optional: isOptional,
     awaitingConfirmation: false,
     isAI: Boolean(player.isAI),
   };

--- a/src/app/ui/views/game/logs.js
+++ b/src/app/ui/views/game/logs.js
@@ -56,7 +56,7 @@ function renderLogSection({ title, className = '', entries = [], expanded = fals
 
 function renderActiveSpellSlot(game) {
   const pending = game.pendingAction;
-  if (pending && pending.type === 'ability') {
+  if (pending && (pending.type === 'ability' || pending.type === 'trigger')) {
     return `
       <section class="active-spell-panel empty">
         <div class="panel-header">

--- a/src/game/cards/green-cards/green-creatures.js
+++ b/src/game/cards/green-cards/green-creatures.js
@@ -103,8 +103,15 @@ export const greenCreatures = [
     toughness: 4,
     passive: {
       type: 'onAttack',
-      description: 'When it attacks, give another friendly creature +1/+1.',
-      effect: { type: 'buff', target: 'friendly-creature', attack: 1, toughness: 1, excludeSelf: true },
+      description: 'When attacking, you may give another creature a +1/+1 counter.',
+      effect: {
+        type: 'buff',
+        target: 'friendly-creature',
+        attack: 1,
+        toughness: 1,
+        excludeSelf: true,
+        optional: true,
+      },
     },
     text: 'Inspires allies mid-battle.',
   },

--- a/src/style.css
+++ b/src/style.css
@@ -858,7 +858,7 @@ input {
   min-height: 140px;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  grid-auto-rows: 1fr;
+  grid-auto-rows: auto;
   gap: 0.6rem;
   align-content: start;
   padding: clamp(0.7rem, 1.2vw, 1.05rem);
@@ -889,7 +889,8 @@ input {
 }
 
 .battlefield .card {
-  height: 100%;
+  height: auto;
+  align-self: start;
 }
 
 .card.card-color-red.creature-card {


### PR DESCRIPTION
## Summary
- make Nature's Herald's attack trigger optional with a cancel path that advances combat correctly
- prevent attack triggers from occupying the active spell slot and adjust battlefield layout so only the acting card grows
- update battlefield grid styling so individual cards expand without stretching their neighbors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4bcceab14832aab3aeb8f2e93097f