### PR TITLE
Ensure frozen status locks actions and refresh hero menus

### DIFF
--- a/src/app/game/ai.js
+++ b/src/app/game/ai.js
@@ -2,6 +2,7 @@ import { state, requestRender } from '../state.js';
 import { addLog, cardSegment, playerSegment, textSegment } from './log.js';
 import { skipCombat, startTriggerStage } from './combat/index.js';
 import { getCreatureStats } from './creatures.js';
+import { isEligibleAttacker } from './combat/helpers.js';
 
 let helpers = {
   advancePhase: () => {},
@@ -183,7 +184,7 @@ function aiDeclareAttacks() {
   if (!game.combat) {
     return;
   }
-  const attackers = game.players[1].battlefield.filter((c) => c.type === 'creature' && !c.summoningSickness);
+  const attackers = game.players[1].battlefield.filter(isEligibleAttacker);
   if (attackers.length === 0) {
     addLog('No attackers declared.');
     // Allow a beat before skipping combat to make the flow readable

--- a/src/app/game/core/stats.js
+++ b/src/app/game/core/stats.js
@@ -1,0 +1,72 @@
+import { state } from '../../state.js';
+
+function createPlayerStats() {
+  return {
+    cardsPlayed: 0,
+    spellsCast: 0,
+    creaturesSummoned: 0,
+    creaturesDestroyed: 0,
+    creaturesLost: 0,
+    damageDealt: 0,
+    turnsTaken: 0,
+  };
+}
+
+export function createInitialStats() {
+  return {
+    totalTurns: 0,
+    players: [createPlayerStats(), createPlayerStats()],
+  };
+}
+
+function getStats() {
+  return state.game?.stats;
+}
+
+export function recordTurnStart(playerIndex) {
+  const stats = getStats();
+  if (!stats || typeof playerIndex !== 'number') return;
+  stats.totalTurns += 1;
+  const playerStats = stats.players[playerIndex];
+  if (playerStats) {
+    playerStats.turnsTaken += 1;
+  }
+}
+
+export function recordCardPlay(playerIndex, cardType) {
+  const stats = getStats();
+  if (!stats || typeof playerIndex !== 'number') return;
+  const playerStats = stats.players[playerIndex];
+  if (!playerStats) return;
+  playerStats.cardsPlayed += 1;
+  if (cardType === 'spell') {
+    playerStats.spellsCast += 1;
+  } else if (cardType === 'creature') {
+    playerStats.creaturesSummoned += 1;
+  }
+}
+
+export function recordCreatureLoss(controllerIndex) {
+  const stats = getStats();
+  if (!stats || typeof controllerIndex !== 'number') return;
+  const ownerStats = stats.players[controllerIndex];
+  const opponentIndex = controllerIndex === 0 ? 1 : 0;
+  const opponentStats = stats.players[opponentIndex];
+  if (ownerStats) {
+    ownerStats.creaturesLost += 1;
+  }
+  if (opponentStats) {
+    opponentStats.creaturesDestroyed += 1;
+  }
+}
+
+export function recordDamageToPlayer(targetIndex, amount) {
+  if (!amount || amount <= 0) return;
+  const stats = getStats();
+  if (!stats || typeof targetIndex !== 'number') return;
+  const dealerIndex = targetIndex === 0 ? 1 : 0;
+  const dealerStats = stats.players[dealerIndex];
+  if (dealerStats) {
+    dealerStats.damageDealt += amount;
+  }
+}

--- a/src/app/game/creatures.js
+++ b/src/app/game/creatures.js
@@ -2,6 +2,7 @@ import { createCardInstance } from '../../game/cards/index.js';
 import { requestRender, state } from '../state.js';
 import { addLog, cardSegment, damageSegment, playerSegment, textSegment } from './log.js';
 import { sortHand } from './core/index.js';
+import { recordCreatureLoss, recordDamageToPlayer } from './core/stats.js';
 
 let checkForWinnerHook = () => {};
 
@@ -183,12 +184,14 @@ export function destroyCreature(creature, controllerIndex) {
   }
   delete creature._dying;
   delete creature._destroyScheduled;
+  recordCreatureLoss(controllerIndex);
   player.graveyard.push(creature);
   addLog([cardSegment(creature), textSegment(' dies.')]);
 }
 
 export function dealDamageToPlayer(index, amount) {
   const player = state.game.players[index];
+  recordDamageToPlayer(index, amount);
   player.life -= amount;
   addLog([
     playerSegment(player),

--- a/src/app/ui/effects/index.js
+++ b/src/app/ui/effects/index.js
@@ -1,0 +1,13 @@
+import { attachParticleField, resetParticleFields } from './particleField.js';
+
+const PARTICLE_SCREENS = new Set(['menu', 'mode-select', 'color-select', 'game-over']);
+
+export function enhanceView(root, screen) {
+  resetParticleFields();
+  if (!PARTICLE_SCREENS.has(screen)) {
+    return;
+  }
+  root.querySelectorAll('[data-particle-field]').forEach((container) => {
+    attachParticleField(container);
+  });
+}

--- a/src/app/ui/effects/particleField.js
+++ b/src/app/ui/effects/particleField.js
@@ -1,0 +1,119 @@
+const activeFields = new Set();
+
+function createParticle(width, height) {
+  return {
+    x: Math.random() * width,
+    y: Math.random() * height,
+    vx: (Math.random() - 0.5) * 0.05,
+    vy: 0.2 + Math.random() * 0.35,
+    radius: 0.6 + Math.random() * 1.8,
+    opacity: 0.2 + Math.random() * 0.5,
+  };
+}
+
+export function attachParticleField(container) {
+  if (!container || activeFields.has(container)) return;
+  const canvas = container.querySelector('canvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  let width = 0;
+  let height = 0;
+  let frameId = null;
+  let lastTime = performance.now();
+  const particles = [];
+
+  function handleResize() {
+    const bounds = container.getBoundingClientRect();
+    width = Math.max(1, bounds.width);
+    height = Math.max(1, bounds.height);
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    const targetCount = Math.max(24, Math.floor((width * height) / 6500));
+    while (particles.length < targetCount) {
+      particles.push(createParticle(width, height));
+    }
+    if (particles.length > targetCount) {
+      particles.length = targetCount;
+    }
+  }
+
+  function update(delta) {
+    const drift = delta * 0.06;
+    particles.forEach((particle) => {
+      particle.x += particle.vx * drift;
+      particle.y -= particle.vy * drift;
+      particle.opacity += Math.sin(delta * 0.0005) * 0.002;
+      if (particle.opacity < 0.15) particle.opacity = 0.15;
+      if (particle.opacity > 0.65) particle.opacity = 0.65;
+      if (particle.y + particle.radius < 0) {
+        Object.assign(particle, createParticle(width, height));
+        particle.y = height + particle.radius;
+      }
+      if (particle.x < -20 || particle.x > width + 20) {
+        particle.x = Math.random() * width;
+      }
+    });
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, width, height);
+    particles.forEach((particle) => {
+      ctx.beginPath();
+      ctx.globalAlpha = particle.opacity;
+      const gradient = ctx.createRadialGradient(
+        particle.x,
+        particle.y,
+        0,
+        particle.x,
+        particle.y,
+        particle.radius * 6,
+      );
+      gradient.addColorStop(0, 'rgba(140, 170, 255, 0.9)');
+      gradient.addColorStop(1, 'rgba(140, 170, 255, 0)');
+      ctx.fillStyle = gradient;
+      ctx.arc(particle.x, particle.y, particle.radius * 6, 0, Math.PI * 2);
+      ctx.fill();
+    });
+    ctx.globalAlpha = 1;
+  }
+
+  function loop(now) {
+    const delta = now - lastTime;
+    lastTime = now;
+    update(delta);
+    draw();
+    frameId = requestAnimationFrame(loop);
+  }
+
+  handleResize();
+  window.addEventListener('resize', handleResize);
+  frameId = requestAnimationFrame(loop);
+
+  function cleanup() {
+    if (frameId) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    window.removeEventListener('resize', handleResize);
+    activeFields.delete(container);
+  }
+
+  container.__particleCleanup = cleanup;
+  activeFields.add(container);
+}
+
+export function resetParticleFields() {
+  activeFields.forEach((container) => {
+    if (container.__particleCleanup) {
+      container.__particleCleanup();
+      delete container.__particleCleanup;
+    }
+  });
+  activeFields.clear();
+}

--- a/src/app/ui/renderRoot.js
+++ b/src/app/ui/renderRoot.js
@@ -2,6 +2,7 @@ import { state } from '../state.js';
 import { renderLoading, renderLogin, renderMenu, renderModeSelect, renderColorSelect, renderGameOver } from './views/basicViews.js';
 import { renderGame } from './views/game/index.js';
 import { attachEventHandlers } from './events.js';
+import { enhanceView } from './effects/index.js';
 
 export function renderApp(root) {
   const { screen } = state;
@@ -23,4 +24,5 @@ export function renderApp(root) {
   }
   root.innerHTML = content;
   attachEventHandlers(root);
+  enhanceView(root, screen);
 }

--- a/src/app/ui/views/basicViews.js
+++ b/src/app/ui/views/basicViews.js
@@ -1,5 +1,6 @@
 import { state } from '../../state.js';
 import { COLORS } from '../../../game/cards/index.js';
+import { escapeHtml } from './game/shared.js';
 
 export function renderLoading() {
   return `
@@ -39,12 +40,26 @@ export function renderLogin() {
 
 export function renderMenu() {
   return `
-    <div class="view view-center">
-      <div class="card panel">
-        <h1>Fight Cards</h1>
-        <p class="subtitle">Three elements collide in strategic battles.</p>
-        <button class="primary" data-action="start">Start Game</button>
-        <button data-action="signout">Sign out</button>
+    <div class="view hero-view">
+      <div class="hero-background" data-particle-field>
+        <canvas class="particle-canvas" aria-hidden="true"></canvas>
+        <div class="hero-gradient"></div>
+      </div>
+      <div class="hero-panel">
+        <div class="hero-header">
+          <span class="hero-kicker">Strategy Card Battler</span>
+          <h1>Fight Cards</h1>
+          <p>Three elements clash in fast, tactical duels built for any screen.</p>
+        </div>
+        <ul class="hero-feature-list">
+          <li><strong>Build momentum</strong> with elemental synergies.</li>
+          <li><strong>React instantly</strong> to freezes, buffs, and combat tricks.</li>
+          <li><strong>Play anywhere</strong> with a touch-friendly interface.</li>
+        </ul>
+        <div class="hero-actions">
+          <button class="primary large" data-action="start">Start Battle</button>
+          <button class="ghost large" data-action="signout">Sign out</button>
+        </div>
       </div>
     </div>
   `;
@@ -52,12 +67,32 @@ export function renderMenu() {
 
 export function renderModeSelect() {
   return `
-    <div class="view view-center">
-      <div class="card panel">
-        <h2>Select Mode</h2>
-        <button class="primary" data-action="choose-mode" data-mode="ai">Battle AI</button>
-        <button class="disabled" disabled>Player vs Player (coming soon)</button>
-        <button data-action="back-menu">Back</button>
+    <div class="view hero-view">
+      <div class="hero-background" data-particle-field>
+        <canvas class="particle-canvas" aria-hidden="true"></canvas>
+        <div class="hero-gradient"></div>
+      </div>
+      <div class="hero-panel compact">
+        <div class="hero-header">
+          <span class="hero-kicker">Choose Your Challenge</span>
+          <h2>Select Mode</h2>
+          <p>Decide how you want to enter the arena.</p>
+        </div>
+        <div class="hero-card-grid">
+          <button class="info-card" data-action="choose-mode" data-mode="ai">
+            <span class="info-card-title">Battle AI</span>
+            <span class="info-card-body">Face a reactive opponent tuned for punchy, strategic turns.</span>
+            <span class="info-card-tag">Single player</span>
+          </button>
+          <div class="info-card disabled" aria-disabled="true">
+            <span class="info-card-title">Player vs Player</span>
+            <span class="info-card-body">Challenge friends online in a future update.</span>
+            <span class="info-card-tag">Coming soon</span>
+          </div>
+        </div>
+        <div class="hero-actions">
+          <button class="ghost large" data-action="back-menu">Back</button>
+        </div>
       </div>
     </div>
   `;
@@ -65,22 +100,33 @@ export function renderModeSelect() {
 
 export function renderColorSelect() {
   return `
-    <div class="view view-center">
-      <div class="card panel">
-        <h2>Choose Your Element</h2>
-        <div class="color-grid">
+    <div class="view hero-view">
+      <div class="hero-background" data-particle-field>
+        <canvas class="particle-canvas" aria-hidden="true"></canvas>
+        <div class="hero-gradient"></div>
+      </div>
+      <div class="hero-panel wide">
+        <div class="hero-header">
+          <span class="hero-kicker">Forge Your Identity</span>
+          <h2>Choose Your Element</h2>
+          <p>Each element bends the battlefield in a different way. Tap a deck to begin.</p>
+        </div>
+        <div class="hero-card-grid color-grid">
           ${Object.entries(COLORS)
             .map(
               ([colorKey, info]) => `
-                <button class="color-card" data-action="select-color" data-color="${colorKey}">
-                  <span class="color-title">${info.name}</span>
-                  <span class="color-desc">${info.theme}</span>
+                <button class="info-card color-card color-${colorKey}" data-action="select-color" data-color="${colorKey}">
+                  <span class="info-card-title">${escapeHtml(info.name)}</span>
+                  <span class="info-card-body">${escapeHtml(info.theme)}</span>
+                  <span class="info-card-tag">Elemental focus</span>
                 </button>
               `,
             )
             .join('')}
         </div>
-        <button data-action="back-menu">Back</button>
+        <div class="hero-actions">
+          <button class="ghost large" data-action="back-menu">Back</button>
+        </div>
       </div>
     </div>
   `;
@@ -89,14 +135,102 @@ export function renderColorSelect() {
 export function renderGameOver() {
   const { game } = state;
   if (!game) return '';
-  const winnerText = game.winner === 0 ? 'You won!' : game.winner === 1 ? 'AI wins.' : 'Game ended.';
+  const winnerIndex = game.winner;
+  const players = game.players || [];
+  const stats = game.stats?.players || [];
+  const totalTurns = game.stats?.totalTurns ?? game.turn ?? 0;
+  const playerName = players[0]?.name ?? 'You';
+  const opponentName = players[1]?.name ?? 'Opponent';
+  const winnerText =
+    winnerIndex === 0
+      ? 'Victory!'
+      : winnerIndex === 1
+      ? 'Defeat'
+      : 'Battle Complete';
+  const winnerDetail =
+    winnerIndex === 0
+      ? `${playerName} outlasted ${opponentName}.`
+      : winnerIndex === 1
+      ? `${opponentName} claimed the win.`
+      : 'No victor emerged this time.';
+  const statTemplate = {
+    cardsPlayed: 0,
+    creaturesSummoned: 0,
+    creaturesDestroyed: 0,
+    damageDealt: 0,
+    turnsTaken: 0,
+  };
+  const ensureStats = (index) => ({ ...statTemplate, ...(stats[index] || {}) });
+  const playerStats = ensureStats(0);
+  const opponentStats = ensureStats(1);
+  const statRows = [
+    { label: 'Cards Played', player: playerStats.cardsPlayed, opponent: opponentStats.cardsPlayed },
+    { label: 'Creatures Summoned', player: playerStats.creaturesSummoned, opponent: opponentStats.creaturesSummoned },
+    { label: 'Creatures Destroyed', player: playerStats.creaturesDestroyed, opponent: opponentStats.creaturesDestroyed },
+    { label: 'Damage Dealt', player: playerStats.damageDealt, opponent: opponentStats.damageDealt },
+    { label: 'Turns Taken', player: playerStats.turnsTaken, opponent: opponentStats.turnsTaken },
+  ];
+  const summaries = players
+    .map((player, idx) => {
+      const colorInfo = COLORS[player?.color] || { name: 'Unknown', theme: '' };
+      const resultLabel = winnerIndex == null ? 'Finalist' : winnerIndex === idx ? 'Winner' : 'Challenger';
+      return `
+        <div class="player-summary ${winnerIndex === idx ? 'winner' : ''}">
+          <div class="player-summary-header">
+            <h3>${escapeHtml(player?.name ?? `Player ${idx + 1}`)}</h3>
+            <span class="player-result">${escapeHtml(resultLabel)}</span>
+          </div>
+          <div class="player-summary-meta">
+            <span class="player-deck">${escapeHtml(colorInfo.name)} Deck</span>
+            <span class="player-life">Life ${escapeHtml(player?.life ?? 0)}</span>
+          </div>
+          <p class="player-theme">${escapeHtml(colorInfo.theme)}</p>
+        </div>
+      `;
+    })
+    .join('');
   return `
-    <div class="view view-center">
-      <div class="card panel">
-        <h2>${winnerText}</h2>
-        <p>The battle is over. Ready to try again?</p>
-        <button class="primary" data-action="restart">Play Again</button>
-        <button data-action="back-menu">Main Menu</button>
+    <div class="view hero-view">
+      <div class="hero-background" data-particle-field>
+        <canvas class="particle-canvas" aria-hidden="true"></canvas>
+        <div class="hero-gradient"></div>
+      </div>
+      <div class="hero-panel gameover">
+        <div class="hero-header">
+          <span class="hero-kicker">Battle Report</span>
+          <h2>${escapeHtml(winnerText)}</h2>
+          <p>${escapeHtml(winnerDetail)} After ${escapeHtml(totalTurns)} turn${totalTurns === 1 ? '' : 's'}.</p>
+        </div>
+        <div class="battle-summary">${summaries}</div>
+        <div class="battle-stats">
+          <h3>Match Stats</h3>
+          <table class="stat-table">
+            <thead>
+              <tr>
+                <th scope="col">Stat</th>
+                <th scope="col">${escapeHtml(playerName)}</th>
+                <th scope="col">${escapeHtml(opponentName)}</th>
+              </tr>
+            </thead>
+            <tbody>
+              ${statRows
+                .map(
+                  (row) => `
+                    <tr>
+                      <th scope="row">${escapeHtml(row.label)}</th>
+                      <td>${escapeHtml(row.player)}</td>
+                      <td>${escapeHtml(row.opponent)}</td>
+                    </tr>
+                  `,
+                )
+                .join('')}
+            </tbody>
+          </table>
+        </div>
+        <div class="hero-actions">
+          <button class="primary large" data-action="restart">Play Again</button>
+          <button class="ghost large" data-action="back-menu">Main Menu</button>
+        </div>
       </div>
     </div>
   `;

--- a/src/app/ui/views/game/battlefield.js
+++ b/src/app/ui/views/game/battlefield.js
@@ -308,12 +308,15 @@ function renderCreature(creature, controllerIndex, game) {
   }
   const abilityButtons = [];
   if (creature.activated) {
-    const canActivate = controllerIndex === 0 &&
-                       !creature.activatedThisTurn &&
-                       (!game.pendingAction || (game.pendingAction.type === 'ability' && game.pendingAction.card?.instanceId === creature.instanceId)) &&
-                       game.players[controllerIndex].availableMana >= creature.activated.cost &&
-                       (game.phase === 'main1' || game.phase === 'main2') &&
-                       game.currentPlayer === controllerIndex;
+    const canActivate =
+      controllerIndex === 0 &&
+      !creature.activatedThisTurn &&
+      !(creature.frozenTurns > 0) &&
+      (!game.pendingAction ||
+        (game.pendingAction.type === 'ability' && game.pendingAction.card?.instanceId === creature.instanceId)) &&
+      game.players[controllerIndex].availableMana >= creature.activated.cost &&
+      (game.phase === 'main1' || game.phase === 'main2') &&
+      game.currentPlayer === controllerIndex;
     const abilityName = creature.activated.name ? `${escapeHtml(creature.activated.name)}:` : 'Ability:';
     abilityButtons.push(
       `<div class="ability-row">

--- a/src/game/cards/blue-cards/blue-creatures.js
+++ b/src/game/cards/blue-cards/blue-creatures.js
@@ -6,8 +6,13 @@ export const blueCreatures = [
     cost: 1,
     color: 'blue',
     attack: 1,
-    toughness: 2,
-    text: 'Resilient initiate of the tide.',
+    toughness: 1,
+    passive: {
+      type: 'onAttack',
+      description: 'When Wave Adept attacks, draw a card.',
+      effect: { type: 'draw', amount: 1 },
+    },
+    text: 'Learns from every strike.',
   },
   {
     id: 'blue_creature_2',

--- a/src/style.css
+++ b/src/style.css
@@ -74,6 +74,310 @@ body {
   gap: 1rem;
 }
 
+.hero-view {
+  position: relative;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 6vw, 4rem);
+  min-height: min(720px, 100%);
+  overflow: hidden;
+}
+
+.hero-background {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.hero-background .particle-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  opacity: 0.55;
+}
+
+.hero-gradient {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top right, rgba(78, 98, 255, 0.45), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(168, 85, 247, 0.35), transparent 60%);
+  opacity: 0.85;
+}
+
+.hero-panel {
+  position: relative;
+  z-index: 1;
+  width: min(760px, 100%);
+  background: rgba(11, 16, 34, 0.88);
+  border-radius: 28px;
+  padding: clamp(1.8rem, 4vw, 3rem);
+  border: 1px solid rgba(114, 144, 255, 0.35);
+  box-shadow: 0 35px 65px rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(12px);
+}
+
+.hero-panel.compact {
+  width: min(640px, 100%);
+}
+
+.hero-panel.wide {
+  width: min(900px, 100%);
+}
+
+.hero-panel.gameover {
+  width: min(960px, 100%);
+}
+
+.hero-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.hero-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: rgba(190, 205, 255, 0.75);
+}
+
+.hero-header h1,
+.hero-header h2,
+.hero-header h3 {
+  margin: 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.1;
+}
+
+.hero-header p {
+  margin: 0;
+  color: rgba(214, 225, 255, 0.85);
+  font-size: clamp(1rem, 2.4vw, 1.15rem);
+}
+
+.hero-feature-list {
+  list-style: none;
+  margin: 0 0 2rem 0;
+  padding: 0;
+  display: grid;
+  gap: 0.9rem;
+  color: rgba(214, 225, 255, 0.9);
+  font-size: 1rem;
+}
+
+.hero-feature-list li strong {
+  color: #f6f7ff;
+}
+
+.hero-card-grid {
+  display: grid;
+  gap: 1rem;
+  margin-bottom: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.info-card {
+  border: 1px solid rgba(120, 140, 255, 0.25);
+  border-radius: 20px;
+  background: rgba(30, 38, 72, 0.72);
+  padding: 1.25rem;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: transform 0.25s ease, border 0.25s ease, box-shadow 0.25s ease;
+  cursor: pointer;
+}
+
+.info-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(177, 196, 255, 0.8);
+  box-shadow: 0 18px 45px rgba(70, 90, 200, 0.35);
+}
+
+.info-card.disabled {
+  cursor: default;
+  opacity: 0.65;
+  transform: none;
+  border-style: dashed;
+}
+
+.info-card.disabled:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+.info-card-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #f5f7ff;
+}
+
+.info-card-body {
+  color: rgba(214, 225, 255, 0.82);
+  font-size: 0.98rem;
+  line-height: 1.4;
+}
+
+.info-card-tag {
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(178, 195, 255, 0.75);
+}
+
+.color-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.color-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.color-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.1), transparent 70%);
+  pointer-events: none;
+}
+
+.color-red {
+  border-color: rgba(255, 128, 108, 0.4);
+}
+
+.color-blue {
+  border-color: rgba(108, 168, 255, 0.4);
+}
+
+.color-green {
+  border-color: rgba(133, 232, 161, 0.4);
+}
+
+.battle-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.player-summary {
+  background: linear-gradient(135deg, rgba(70, 88, 180, 0.55), rgba(46, 64, 140, 0.55));
+  border: 1px solid rgba(124, 145, 255, 0.35);
+  border-radius: 20px;
+  padding: 1.2rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.player-summary.winner {
+  border-color: rgba(255, 196, 110, 0.7);
+  box-shadow: 0 20px 45px rgba(255, 196, 110, 0.22);
+}
+
+.player-summary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.player-summary-header h3 {
+  margin: 0;
+  font-size: 1.4rem;
+}
+
+.player-result {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 230, 170, 0.9);
+}
+
+.player-summary-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  color: rgba(210, 220, 255, 0.85);
+}
+
+.player-theme {
+  margin: 0;
+  color: rgba(214, 225, 255, 0.75);
+  font-size: 0.95rem;
+}
+
+.battle-stats {
+  margin-bottom: 2.5rem;
+}
+
+.battle-stats h3 {
+  margin: 0 0 0.75rem 0;
+}
+
+.stat-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: rgba(19, 26, 54, 0.8);
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(120, 140, 255, 0.2);
+}
+
+.stat-table th,
+.stat-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+}
+
+.stat-table thead {
+  background: rgba(45, 58, 110, 0.85);
+}
+
+.stat-table thead th {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: rgba(205, 215, 255, 0.75);
+}
+
+.stat-table tbody tr:nth-child(even) {
+  background: rgba(32, 42, 78, 0.6);
+}
+
+.stat-table tbody th {
+  color: rgba(214, 225, 255, 0.9);
+  font-weight: 600;
+}
+
+.stat-table tbody td {
+  color: rgba(214, 225, 255, 0.85);
+}
+
+@media (max-width: 600px) {
+  .hero-panel {
+    padding: 1.5rem;
+  }
+
+  .hero-header h1,
+  .hero-header h2 {
+    font-size: clamp(1.8rem, 8vw, 2.4rem);
+  }
+
+  .hero-feature-list {
+    font-size: 0.95rem;
+  }
+
+  .hero-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
 .view-center {
   justify-content: center;
   align-items: center;
@@ -130,6 +434,31 @@ button.primary {
   background: linear-gradient(135deg, #ff512f, #f09819);
 }
 
+.hero-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.hero-actions button {
+  margin: 0;
+}
+
+button.large {
+  font-size: 1.08rem;
+  padding: 1rem 1.4rem;
+}
+
+button.ghost {
+  background: rgba(15, 20, 34, 0.6);
+  border: 1px solid rgba(160, 178, 255, 0.45);
+  color: rgba(214, 225, 255, 0.95);
+}
+
+button.ghost:hover {
+  box-shadow: 0 16px 35px rgba(120, 140, 255, 0.35);
+}
+
 form.form {
   display: flex;
   flex-direction: column;
@@ -143,37 +472,6 @@ input {
   padding: 0.7rem;
   background: rgba(255, 255, 255, 0.08);
   color: #fff;
-}
-
-.color-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-  margin-bottom: 1rem;
-}
-
-.color-card {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  background: rgba(255, 255, 255, 0.08);
-  border-radius: 14px;
-  padding: 1rem;
-  border: 1px solid transparent;
-}
-
-.color-card:hover {
-  border-color: rgba(255, 255, 255, 0.3);
-}
-
-.color-title {
-  font-size: 1.1rem;
-  font-weight: 700;
-}
-
-.color-desc {
-  font-size: 0.85rem;
-  color: #d1d6ff;
 }
 
 .game-view {


### PR DESCRIPTION
## Summary
- block frozen creatures from AI attacks, player activations, and post-selection ability execution while logging freezes
- add match tracking utilities and surface deck, life, and stat summaries on the game over screen
- redesign the main menus with hero panels, animated particle backdrops, and larger controls for touch devices, and refresh Wave Adept's on-attack draw ability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4ce42ce2c832a945ee8061a51c980