### PR TITLE
Add project readme and gameplay docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,104 @@
+# FightCards
+
+FightCards is a fast-paced, turn-based card battler where elemental decks clash in short, tactical matches. Players build momentum each round, summon creatures, and unleash spells to overwhelm their opponent. The current release focuses on single-player battles against a reactive AI, and the project is being actively prepared for head-to-head multiplayer using InstantDB-backed lobbies and real-time state sync.
+
+## Table of Contents
+- [Project Status](#project-status)
+- [Tech Stack & Dependencies](#tech-stack--dependencies)
+- [Getting Started](#getting-started)
+- [Game Overview](#game-overview)
+  - [Turn Structure & Phases](#turn-structure--phases)
+  - [Resources & Mana Curve](#resources--mana-curve)
+  - [Card Types](#card-types)
+  - [Deck Archetypes](#deck-archetypes)
+- [Multiplayer Vision](#multiplayer-vision)
+- [Documentation](#documentation)
+
+## Project Status
+- ✅ **Single-player vs. AI** — fully playable with three elemental decks.
+- 🚧 **Multiplayer (Player vs. Player)** — design in progress. Lobby creation, matchmaking, and synchronized turns will be powered by InstantDB.
+- 🛣️ **Content Expansion** — documentation for extending spell, creature, and deck systems is included in the `docs/` folder to support new colors (for example, an Air/Lightning "Purple" deck).
+
+## Tech Stack & Dependencies
+- [Node.js 18+](https://nodejs.org/) — development runtime.
+- [Vite](https://vitejs.dev/) — build tool and dev server.
+- [Three.js](https://threejs.org/) — used for the animated 3D background layer.
+- [@instantdb/core](https://www.instantdb.com/docs) — planned backend for multiplayer lobbies and live game state.
+- [gh-pages](https://github.com/tschaub/gh-pages) — optional deployment helper for publishing static builds.
+
+You can review the complete dependency list in [`package.json`](./package.json).
+
+## Getting Started
+1. **Clone the repository**
+   ```bash
+   git clone <repository-url>
+   cd fightcards
+   ```
+2. **Install dependencies**
+   ```bash
+   npm install
+   ```
+3. **Run the development server**
+   ```bash
+   npm run dev
+   ```
+   Vite will print a local URL (usually `http://localhost:5173`) where you can test the game.
+4. **Build for production**
+   ```bash
+   npm run build
+   ```
+5. **Preview a production build**
+   ```bash
+   npm run preview
+   ```
+
+## Game Overview
+FightCards pits two elemental decks against each other. Each deck is composed of creatures and spells that reflect a specific color identity. Matches typically last 10–15 minutes and revolve around tempo, board control, and smart spell timing.
+
+### Turn Structure & Phases
+Every turn advances through three primary phases, managed by the game flow logic:
+1. **Main Phase I** — Play creatures and spells using your available mana. Activated abilities can also be triggered here.
+2. **Combat Phase** — Declare attackers, assign blockers, and resolve combat damage. Certain spells can skip combat or modify it mid-flow.
+3. **Main Phase II / End of Turn** — Finish playing cards, then end your turn. Damage on creatures is cleared and temporary buffs expire at end of turn.
+
+The turn order is determined at the start of the game by an initiative dice roll. Players draw one card per turn, and the active player’s mana pool refills and grows by one each round.
+
+### Resources & Mana Curve
+- Players start with zero mana crystals and gain one maximum mana at the beginning of each turn (`maxMana += 1`).
+- Available mana is refreshed to the new maximum during the upkeep step (`availableMana = maxMana`).
+- Mana is spent to cast spells or summon creatures. Cards are sorted by cost in-hand to encourage curve-based play.
+- Some abilities (for example, activated abilities on creatures) require additional mana payments and track once-per-turn usage.
+
+### Card Types
+- **Creatures** — Permanents that attack, block, and may carry passive, triggered, or activated abilities. Examples include:
+  - *On-enter effects* (e.g., damage, bounce, buffs).
+  - *Triggered abilities* on attack or upkeep.
+  - *Activated abilities* with costs and turn limits.
+  - Keywords such as **Haste** (attack immediately), **Shimmer** (unblockable), or status effects like **Frozen**.
+- **Spells** — One-shot effects resolved via the effect system. Effects cover direct damage, card draw, freezing, token creation, buffs, mass bounce, global prevention, splash damage, and more. Spells can require target selection and may create multiple effects per cast.
+
+### Deck Archetypes
+Each color currently ships with 10 unique creatures and 10 spells. Decks are built by duplicating each entry, resulting in consistent 40-card lists that emphasize their theme:
+- **Fire (Red)** — Aggressive damage, haste creatures, direct burn, and global attack buffs.
+- **Water (Blue)** — Control-oriented bounce, freeze effects, card advantage, and shimmer-enabled evasive threats.
+- **Grass (Green)** — Resilient board growth, permanent buffs, life gain, and powerful late-game finishers.
+
+Deck construction is centralized in [`src/game/cards`](./src/game/cards), where each color exports its creature and spell collections. See [`docs/deck-creation.md`](./docs/deck-creation.md) for standards when adding new colors such as a Purple (Air/Lightning) deck.
+
+## Multiplayer Vision
+The upcoming multiplayer mode will mirror the single-player experience while synchronizing state through InstantDB:
+- **Lobby Browser** — A multiplayer menu will list open lobbies, allowing players to create or join rooms and pick their deck color.
+- **Ready-Up Flow** — Each participant locks in a color, marks ready, and the server coordinates the initial dice roll and turn assignment.
+- **Perspective Handling** — Regardless of seat, the UI will always render the local player at the bottom of the battlefield with identical controls to the AI mode.
+- **Turn Sync** — Game actions (card plays, combat declarations, log events) will be persisted in InstantDB so both clients stay in sync and can safely reconnect.
+- **Security & Fair Play** — Deterministic resolution and server-tracked pending actions will prevent race conditions, ensuring each turn waits for the opposing player’s confirmation.
+
+These plans guide the new documentation so future features (spectating, rematches, seasonal ladders) can build on the same architecture.
+
+## Documentation
+Extended design notes live in the [`docs/`](./docs) directory:
+- [`docs/creature-mechanics.md`](./docs/creature-mechanics.md) — lifecycle of creatures, statuses, and ability types.
+- [`docs/spell-mechanics.md`](./docs/spell-mechanics.md) — spell resolution pipeline, effect catalog, and targeting rules.
+- [`docs/deck-creation.md`](./docs/deck-creation.md) — guidelines for designing balanced decks, including color identity and multiplayer considerations.
+
+Contributions that add new mechanics or multiplayer systems should update both the codebase and relevant docs to keep the design playbook fresh.

--- a/docs/creature-mechanics.md
+++ b/docs/creature-mechanics.md
@@ -1,0 +1,50 @@
+# Creature Mechanics
+
+This document outlines how creature cards behave inside FightCards. Use it as a reference when authoring new cards or extending combat logic, especially as we move toward synchronized multiplayer matches.
+
+## Lifecycle Overview
+1. **Deck Construction** — Creature definitions live under `src/game/cards/<color>-cards/<color>-creatures.js`. During deck build, each definition is duplicated to create a 40-card deck (20 creatures + 20 spells).
+2. **Summoning**
+   - Creatures can be played during Main Phase I or II if the controller has enough available mana.
+   - On cast, the creature is removed from the player’s hand, mana is spent, and the creature is initialized with its base stats and status flags.
+   - If the creature has an `onEnter` passive that requires targets, the game creates a pending action so the controller can select them before the card resolves. This flow must be mirrored for remote opponents during multiplayer.
+3. **Battlefield State**
+   - Creatures track `baseAttack`, `baseToughness`, current buffs, `damageMarked`, `summoningSickness`, and optional ability flags (`haste`, `shimmer`, etc.).
+   - Each turn, frozen counters tick down, activated ability flags reset, and temporary haste expires.
+   - Damage marked is cleared at the end of each turn.
+4. **Leaving Play**
+   - Destroyed creatures move to the graveyard and reset transient state.
+   - Bounced creatures return to hand, lose temporary buffs, and regain summoning sickness unless they natively have haste.
+   - Tokens disappear when they would leave the battlefield instead of returning to hand.
+
+## Ability Types
+Creatures can mix and match the following ability patterns:
+
+- **Static Buffs** — Always-on effects that modify allied creatures. Example: `globalBuff` raising attack or toughness for friendly units.
+- **Triggered Passives**
+  - `onEnter`: Fires when the creature resolves onto the battlefield.
+  - `onAttack`: Fires when the creature is declared as an attacker.
+  - Additional hooks can be introduced by extending the passive handler registry in `src/app/game/core/flow.js`.
+- **Activated Abilities** — Invoked manually during the controller’s main phases if they can pay the mana cost. Activated abilities can be limited to once per turn.
+- **Keyword Abilities**
+  - **Haste** — Creature ignores summoning sickness and may attack immediately.
+  - **Shimmer** — Creature is unblockable for as long as it has shimmer. Temporary shimmer is tracked as a buff that expires at end of turn.
+  - **Frozen** — A status applied by some spells; the creature skips its next attack/block and loses one frozen counter at the start of each turn.
+
+## Buff Systems
+- **Permanent Buffs** (`buff`, `globalBuff`, `selfBuff`) change a creature’s base stats. These stack with previous permanent adjustments.
+- **Temporary Buffs** (`temporaryBuff`) apply until end of turn and live inside the creature’s `buffs` array.
+- **Granting Keywords** (`grantHaste`, `grantShimmer`) uses the same buff array to track expirations when the duration is `turn`.
+- **Counters & Growth** — Some creatures add repeatable permanent buffs through activated abilities (e.g., Blooming Hydra). Ensure multiplayer updates to these stats are transactional to avoid desync.
+
+## Combat Participation
+- **Attacking** — Creatures without summoning sickness (or with haste) can attack during the combat phase. Attack toggling is part of the combat stage state machine.
+- **Blocking** — Defending players assign blockers based on targeting requirements handled by `combat/helpers.js`.
+- **Damage Resolution** — Damage is marked, logged, and lethal amounts schedule a destroy action. Effects like `preventCombatDamage` or `preventDamageToAttackers` modify this pipeline.
+
+## Multiplayer Considerations
+- **Authoritative State** — When implementing multiplayer, creature updates (summoning, buffs, damage) should be written to InstantDB as discrete events so both clients reconstruct the same state machine.
+- **Pending Actions** — Passive triggers that require player input must pause the turn timer and await the remote player’s choice. Store pending action metadata (card, effect index, chosen targets) centrally.
+- **Perspective Lock** — Always serialize seat-relative information (controller index, instance IDs) so the UI can render the local player at the bottom regardless of lobby seat.
+
+By following these mechanics, new creature designs—such as those in a future Purple (Air/Lightning) deck—will integrate smoothly with combat, AI, and forthcoming multiplayer synchronization.

--- a/docs/deck-creation.md
+++ b/docs/deck-creation.md
@@ -1,0 +1,40 @@
+# Deck Creation Standards
+
+Use this guide when authoring new deck colors or tweaking existing ones. The goal is to maintain balance, preserve each color’s identity, and prepare the card pool for seamless multiplayer play.
+
+## Core Deck Structure
+- **Card Count** — Each deck contains 20 unique definitions (10 creatures, 10 spells). The deck builder duplicates every entry, resulting in a 40-card list.
+- **Mana Curve** — Creature and spell costs should span 1–6 mana. Early drops enable board presence, while higher-cost cards offer finishers or swingy spells.
+- **Theme Consistency** — Every color focuses on a distinct playstyle:
+  - **Red (Fire)** — Aggression, haste, and direct damage.
+  - **Blue (Water)** — Control, bounce, freeze, and card draw.
+  - **Green (Grass)** — Growth, life gain, and resilient creatures.
+  When creating a new deck (e.g., **Purple / Air-Lightning**), define a clear theme such as evasion, tempo swings, or chain lightning effects.
+
+## Design Checklist for New Colors
+1. **Color Identity Document** — Draft a short brief covering combat philosophy, resource patterns, and signature mechanics.
+2. **Creature Suite**
+   - Include a mix of vanilla bodies, utility creatures with `onEnter` effects, and at least one card featuring an activated ability.
+   - Provide 2–3 keyword-bearing creatures. For a Purple deck, consider new keywords (e.g., `storm` for extra spell triggers) and document them in `docs/creature-mechanics.md`.
+   - Ensure late-game creatures can close matches without being strictly better than other colors’ finishers.
+3. **Spell Suite**
+   - Supply removal, tempo tools, and a marquee spell that expresses the color’s theme.
+   - Reuse existing effect types when possible. If new effect logic is needed, extend `applyEffect` and add entries to `docs/spell-mechanics.md`.
+   - Balance card draw or mana acceleration carefully to avoid runaway advantages in multiplayer.
+4. **Stat & Cost Review** — Compare new cards against existing ones. Aim for parity in total attack/toughness and number of efficient spells.
+5. **AI Compatibility** — If the deck introduces new targeting rules, update `requirements.js` and AI helpers so single-player behavior remains intelligent.
+6. **Multiplayer Readiness**
+   - Design cards to resolve deterministically. Avoid ambiguous triggers that could diverge between clients.
+   - For any card that references opponent choices (e.g., forced discards), outline how those inputs will be captured in InstantDB.
+
+## File Layout
+- Add new creature and spell files under `src/game/cards/<color>-cards/`.
+- Export the combined list in `src/game/cards/<color>-cards/index.js` and register the color inside `src/game/cards/index.js` (`COLORS`, `CARD_LIBRARY`).
+- Provide localized artwork or placeholders as needed by the UI (`src/app/ui`).
+
+## Testing & Validation
+- **Unit Tests / Build** — Run `npm run build` to ensure the project bundles successfully.
+- **Playtest Scripts** — Use the existing single-player mode to check for gameplay loops, ensuring the AI can pilot or counter the new deck.
+- **Documentation Updates** — Append any new mechanics, keywords, or spell effects to the relevant docs so other contributors understand the additions.
+
+By following these standards, a future Purple Air-Lightning deck—and any other expansions—will feel cohesive, balanced, and ready for multiplayer deployment.

--- a/docs/spell-mechanics.md
+++ b/docs/spell-mechanics.md
@@ -1,0 +1,50 @@
+# Spell Mechanics
+
+This guide describes how spell cards are defined and resolved in FightCards. It also highlights considerations for synchronizing spell casting in the upcoming multiplayer mode.
+
+## Spell Definition
+- Spell data is located in `src/game/cards/<color>-cards/<color>-spells.js`.
+- Each spell entry specifies:
+  - `id`, `name`, `color`, `cost`, and descriptive `text`.
+  - An array of `effects`, each with a `type` and optional metadata (targets, amounts, duration, etc.).
+  - Some spells chain multiple effects; they resolve in the order listed.
+
+## Casting Pipeline
+1. **Eligibility Check** — Players can cast spells during Main Phase I or II when they have sufficient mana and it is their turn.
+2. **Pending Action Creation** — The spell is removed from the hand and a pending action is created. Requirements for each effect are computed to determine whether the caster must choose targets.
+3. **Target Selection**
+   - If all requirements can be auto-resolved (e.g., `draw`), the spell moves straight to confirmation.
+   - When player choice is required (such as `damage` to "any"), the UI prompts the caster to select valid targets before InstantDB (in multiplayer) records the final selection.
+4. **Confirmation & Resolution** — Once confirmed, mana is spent and `resolveEffects` walks through the effect list, applying each outcome to the chosen targets.
+5. **Cleanup** — Spells go to the graveyard after resolution, and the game checks for win conditions.
+
+## Effect Catalog
+The current effect system supports a wide range of mechanics. New effects can be added by expanding `applyEffect` in `src/app/game/core/effects.js`.
+
+| Effect Type | Description |
+|-------------|-------------|
+| `damage` | Deal damage to creatures or players. Targets may be specific (`enemy-creature`) or flexible (`any`). |
+| `draw` | Controller draws cards and logs the event. |
+| `damageAllEnemies` / `damageAllCreatures` | Area-of-effect damage across the opposing board, optionally hitting the enemy player. |
+| `temporaryBuff` | Grants attack/toughness until end of turn. |
+| `buff`, `globalBuff`, `multiBuff`, `selfBuff` | Permanent stat increases for single or multiple creatures. |
+| `grantHaste`, `grantShimmer` | Adds keyword abilities, optionally with temporary duration. |
+| `createToken`, `createMultipleTokens` | Summon predefined token creatures to the battlefield. Tokens vanish if bounced or destroyed. |
+| `bounce`, `massBounce`, `bounceAttackers` | Return creatures to hand (tokens are destroyed instead). |
+| `freeze` | Apply frozen counters that prevent attacking/blocking for several turns. |
+| `preventCombatDamage`, `preventDamageToAttackers`, `damageAttackers` | Manipulate combat outcomes during the current turn. |
+| `heal` | Remove marked damage from friendly creatures. |
+| `gainLife` | Increase the controller’s life total. |
+| `teamBuff` | Permanently enhance every creature on the controller’s battlefield. |
+| `revive` | Return the top card of the graveyard to hand. |
+| `splashDamage` | Distribute damage randomly among enemy creatures, spilling over to the opponent if excess remains. |
+
+Refer to existing spells (e.g., *Volcanic Rain*, *Counter Surge*, *Primal Resurgence*) for concrete examples of multi-effect interactions.
+
+## Multiplayer Considerations
+- **Deterministic Resolution** — Store the pending action’s effect list, target selections, and resolution order in InstantDB so both clients can replay the same steps.
+- **Latency Handling** — Because some effects trigger immediate follow-up actions (like tokens entering with passives), queue these events server-side and broadcast them as part of the same transaction.
+- **Visibility** — Spell previews and logs should only expose information available to each player (e.g., hidden hand contents stay private). InstantDB entries should flag whether a log item is public or private.
+- **Concurrency Control** — Only one spell pending action should exist at a time. When multiplayer is implemented, gate the "End Phase" control until the current spell resolves to avoid divergent timelines.
+
+With these rules in place, designers can safely extend the spell roster and ensure that real-time matches remain consistent and fair.


### PR DESCRIPTION
## Summary
- add a comprehensive README with setup, gameplay overview, and multiplayer plans
- create documentation for creature and spell mechanics with multiplayer considerations
- document deck creation standards to guide future colors such as a purple air/lightning deck

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d55f1d7224832ab3f0e7c8d2f9800b