### PR TITLE
Force desktop viewport scaling on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=1200, initial-scale=1.0, maximum-scale=1.0, viewport-fit=cover"
+    />
     <title>fightcards</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary
- configure the viewport meta tag to target a 1200px layout width so mobile browsers use the desktop layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7317eef8c832abbe93c494693a50d