### PR TITLE
Fix multiplayer lobby interactions and initialization

### DIFF
--- a/src/app/state.js
+++ b/src/app/state.js
@@ -23,6 +23,7 @@ export const initialState = {
     activeLobby: null,
     lobbySubscription: null,
     activeLobbySubscription: null,
+    cardCache: null,
     match: null,
     matchSubscription: null,
     matchEvents: [],


### PR DESCRIPTION
## Summary
- add lobby subscription management, lobby creation, and match transition handling to the multiplayer UI
- ensure multiplayer runtime initializes the card cache and game state when match snapshots arrive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7344b7010832a9529e5ab462b84be