### PR TITLE
Fix multiplayer lobby interactions and effects

### DIFF
--- a/src/app/ui/effects/index.js
+++ b/src/app/ui/effects/index.js
@@ -1,6 +1,13 @@
 import { attachParticleField, resetParticleFields } from './particleField.js';
 
-const PARTICLE_SCREENS = new Set(['menu', 'mode-select', 'color-select', 'game-over']);
+const PARTICLE_SCREENS = new Set([
+  'menu',
+  'mode-select',
+  'color-select',
+  'game-over',
+  'multiplayer-lobbies',
+  'multiplayer-lobby-detail',
+]);
 
 export function enhanceView(root, screen) {
   resetParticleFields();


### PR DESCRIPTION
## Summary
- enable lobby screens to render the shared particle background effect
- replace per-element listeners with delegated multiplayer lobby handlers so create/join/back/ready actions work reliably
- clean up lobby subscriptions and search state when leaving or refreshing to keep the lobby list responsive

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7387de89c832aad34ead5db88f8c0