### PR TITLE
Fix InstantDB ID generation for multiplayer lobbies

### DIFF
--- a/docs/multiplayer-schema.md
+++ b/docs/multiplayer-schema.md
@@ -26,16 +26,42 @@ export const schema = i.schema({
       createdAt: i.number().optional(),
       updatedAt: i.number().optional(),
     }),
+    matches: i.entity({
+      lobbyId: i.string().optional(),
+      status: i.string().optional(),
+      activePlayer: i.number().optional(),
+      turn: i.number().optional(),
+      phase: i.string().optional(),
+      dice: i.json().optional(),
+      state: i.json().optional(),
+      pendingAction: i.json().optional(),
+      nextSequence: i.number().optional(),
+      createdAt: i.number().optional(),
+      updatedAt: i.number().optional(),
+      hostUserId: i.string().optional(),
+      guestUserId: i.string().optional(),
+    }),
+    matchEvents: i.entity({
+      matchId: i.string().optional(),
+      sequence: i.number().optional(),
+      type: i.string().optional(),
+      payload: i.json().optional(),
+      createdAt: i.number().optional(),
+    }),
   },
   links: {},
   rooms: {},
 });
 ```
 
+### ID Generation
+
+InstantDB validates that entity primary keys are UUID strings. The client uses `crypto.randomUUID()` (with a deterministic fallback for environments that lack the Web Crypto API) via `generateId()` so that lobby, match, and match-event records always satisfy that requirement.
+
 ### `lobbies`
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Lobby id generated client-side via `generateId('lobby')`. |
+| `id` | string | Lobby id generated client-side via `generateId()`. |
 | `status` | string | `'open' \| 'ready' \| 'starting' \| 'playing' \| 'completed' \| 'abandoned'`; defaults to `'open'`. |
 | `hostUserId` | string | Lobby owner (Instant user id). Empty string means the seat is open. |
 | `hostDisplayName` | string | Cached host name shown in listings. Empty string when unknown. |
@@ -62,7 +88,7 @@ export const schema = i.schema({
 ### `matches`
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Match id |
+| `id` | string | Match id generated with `generateId()` |
 | `lobbyId` | string | Parent lobby id |
 | `status` | string | `'starting' \| 'in-progress' \| 'completed' \| 'abandoned'` |
 | `activePlayer` | number | Seat index of active player (0 host, 1 guest) |
@@ -74,11 +100,13 @@ export const schema = i.schema({
 | `nextSequence` | number | Next `matchEvents.sequence` to assign |
 | `createdAt` | number | Unix epoch |
 | `updatedAt` | number | Unix epoch |
+| `hostUserId` | string | Host user id cached for quick seat lookups |
+| `guestUserId` | string | Guest user id cached for quick seat lookups |
 
 ### `matchEvents`
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Event id |
+| `id` | string | Event id generated with `generateId()` |
 | `matchId` | string | Owning match |
 | `sequence` | number | Strictly increasing sequence number |
 | `type` | string | Event type (see below) |

--- a/src/app/multiplayer/runtime.js
+++ b/src/app/multiplayer/runtime.js
@@ -102,7 +102,7 @@ export async function enqueueMatchEvent(type, payload) {
   const match = state.multiplayer.match;
   const nextSequence = match.nextSequence ?? 1;
   try {
-    const eventId = generateId('matchEvent');
+    const eventId = generateId();
     const now = Date.now();
     const ops = [
       db.tx.matchEvents[eventId].update({

--- a/src/app/ui/multiplayer/events.js
+++ b/src/app/ui/multiplayer/events.js
@@ -416,8 +416,8 @@ async function startMatch() {
 
   if (!ready) return;
 
-  const matchId = generateId('match');
-  const eventId = generateId('matchEvent');
+  const matchId = generateId();
+  const eventId = generateId();
   const now = Date.now();
   const diceRolls = {
     host: 1 + Math.floor(Math.random() * 6),
@@ -605,7 +605,7 @@ async function createLobby() {
 
   try {
     await deleteUserStaleLobbies(user.id);
-    const lobbyId = generateId('lobby');
+    const lobbyId = generateId();
     const now = Date.now();
     const displayName = deriveDisplayName(user);
     const normalizedName = displayName.trim() || 'Player';

--- a/src/app/utils/id.js
+++ b/src/app/utils/id.js
@@ -1,7 +1,21 @@
-export function generateId(prefix = '') {
-  const baseId =
-    typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-      ? crypto.randomUUID()
-      : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
-  return prefix ? `${prefix}_${baseId}` : baseId;
+function fallbackUuid() {
+  let timestamp = Date.now();
+  if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+    timestamp += performance.now();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+    const random = (timestamp + Math.random() * 16) % 16 | 0;
+    timestamp = Math.floor(timestamp / 16);
+    if (char === 'x') {
+      return random.toString(16);
+    }
+    return ((random & 0x3) | 0x8).toString(16);
+  });
+}
+
+export function generateId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return fallbackUuid();
 }


### PR DESCRIPTION
## Summary
- generate UUID-compatible identifiers so InstantDB transactions for lobbies, matches, and events succeed
- update multiplayer event creation code to use the new generator
- extend the multiplayer schema documentation with the InstantDB entity definitions and UUID guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d803e0531c832a978dc0909658c82c