### PR TITLE
Fix multiplayer lobby syncing and layout

### DIFF
--- a/docs/multiplayer-schema.md
+++ b/docs/multiplayer-schema.md
@@ -84,6 +84,9 @@ InstantDB validates that entity primary keys are UUID strings. The client uses `
 - Player name search is performed entirely client-side by matching the lower-cased `hostDisplayName` and `guestDisplayName` fields. The `searchKey` column exists to speed up server-side filtering if rules are added later.
 - Before creating a new lobby, the host deletes any of their previous open rooms that have been idle for 60 seconds. This keeps the listing clean and prevents duplicate "ghost" lobbies from appearing across multiple devices.
 - Joining a lobby installs a dedicated subscription for that record so seat changes, deck picks, and ready states stream into the detail view without polling.
+- Hosts immediately delete their lobby if they navigate back to the lobby list, refresh the page, or start a match. A 60 second TTL (tracked via `updatedAt`) also removes abandoned lobbies if the client disconnects unexpectedly.
+- The client stores the most recent lobby id in `localStorage` so it can be cleaned up automatically after a crash or refresh when the player signs back in.
+- The lobby detail screen renders distinct experiences: the host sees only their deck selection plus an opponent status panel, while guests see host readiness alongside their own deck picker. Spectators are informed when both seats are filled.
 
 ### `matches`
 | Field | Type | Description |

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -2,6 +2,7 @@ import { registerRenderer, setState, state, db } from './state.js';
 import { renderApp } from './ui/renderRoot.js';
 import { initBackground } from './background.js';
 import { describeGameState } from './game/core/index.js';
+import { cleanupRememberedLobbyForUser } from './ui/multiplayer/events.js';
 
 export function setupApp(root) {
   root.innerHTML = '';
@@ -37,6 +38,9 @@ export function setupApp(root) {
       auth: { loading: false, user, error: null },
       screen: user ? 'menu' : 'login',
     });
+    if (user) {
+      cleanupRememberedLobbyForUser(user.id);
+    }
   });
 
   window.addEventListener('focus', () => {

--- a/src/app/multiplayer/runtime.js
+++ b/src/app/multiplayer/runtime.js
@@ -141,7 +141,7 @@ export function subscribeToMatch(matchId) {
     matchEvents: {
       $: {
         where: { matchId },
-        orderBy: [{ field: 'sequence', direction: 'asc' }],
+        limit: 1000,
       },
     },
   };
@@ -159,7 +159,12 @@ export function subscribeToMatch(matchId) {
     if (match) {
       ensureLocalSeat(match);
       ensureCardCache();
-      state.multiplayer.matchEvents = snapshot.data?.matchEvents ?? [];
+      const orderedEvents = [...(snapshot.data?.matchEvents ?? [])].sort((a, b) => {
+        const aSeq = typeof a.sequence === 'number' ? a.sequence : 0;
+        const bSeq = typeof b.sequence === 'number' ? b.sequence : 0;
+        return aSeq - bSeq;
+      });
+      state.multiplayer.matchEvents = orderedEvents;
       state.multiplayer.currentMatchId = match.id;
       ensureGameInitialized();
       applyPendingEvents();

--- a/src/app/ui/views/basicViews.css
+++ b/src/app/ui/views/basicViews.css
@@ -93,60 +93,52 @@
   padding: 1.5rem 0;
 }
 
-.lobby-detail-grid {
+.lobby-detail-columns {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
-  margin-bottom: 1rem;
+  margin-bottom: 1.5rem;
 }
 
-.seat-card {
+.lobby-detail-columns.spectator {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.lobby-card {
   background: rgba(11, 16, 34, 0.85);
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 24px;
   padding: 1.6rem;
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.1rem;
   transition: border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
 }
 
-.seat-card.has-color {
+.lobby-card.deck-red,
+.lobby-card.deck-blue,
+.lobby-card.deck-green,
+.lobby-card.deck-purple,
+.lobby-card.deck-white,
+.lobby-card.deck-black {
   border-color: var(--deck-accent, rgba(96, 165, 250, 0.45));
   box-shadow: 0 18px 45px var(--deck-accent-soft, rgba(96, 165, 250, 0.18));
 }
 
-.seat-card.ready {
-  transform: translateY(-4px);
-}
-
-.seat-header {
+.lobby-card header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
   gap: 1rem;
 }
 
-.seat-heading {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.seat-role {
-  text-transform: uppercase;
-  letter-spacing: 0.14em;
-  font-size: 0.72rem;
-  color: rgba(190, 205, 255, 0.65);
-}
-
-.seat-heading h3 {
+.lobby-card h3 {
   margin: 0;
-  font-size: 1.35rem;
+  font-size: 1.3rem;
   color: #f8fafc;
 }
 
-.seat-status-pill {
+.ready-state {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -160,62 +152,53 @@
   color: rgba(226, 232, 240, 0.85);
 }
 
-.seat-status-pill.ready {
+.ready-state.ready {
   background: var(--deck-accent, rgba(96, 165, 250, 0.75));
   color: #0b1120;
 }
 
-.seat-status-pill.waiting {
+.ready-state.waiting {
   background: rgba(248, 180, 64, 0.25);
   color: rgba(255, 241, 197, 0.95);
 }
 
-.seat-status-pill.open {
+.ready-state.open {
   background: rgba(59, 130, 246, 0.22);
   color: rgba(226, 232, 240, 0.85);
 }
 
-.seat-body {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.seat-deck-summary {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.seat-label {
-  font-size: 0.75rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.7);
-}
-
-.seat-value {
+.lobby-card-label {
+  margin: 0;
   font-size: 1.05rem;
   font-weight: 600;
   color: #f8fafc;
 }
 
-.seat-card.has-color .seat-value {
-  color: var(--deck-accent, #f8fafc);
-}
-
-.seat-card.has-color .seat-theme-text {
-  color: color-mix(in srgb, var(--deck-accent, #94a3ff) 35%, rgba(15, 23, 42, 0.4));
-}
-
-.seat-theme-text {
+.lobby-card-subtitle {
   margin: 0;
   color: rgba(206, 218, 255, 0.82);
-  min-height: 2.5rem;
 }
 
-.seat-controls {
+.ready-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ready-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(248, 180, 64, 0.8);
+}
+
+.opponent-message {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+  line-height: 1.4;
+}
+
+.guest-actions,
+.guest-controls {
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -277,11 +260,6 @@
   margin: 0;
   color: rgba(190, 205, 255, 0.78);
   font-size: 0.95rem;
-}
-
-.seat-actions {
-  display: flex;
-  justify-content: flex-start;
 }
 
 .lobby-detail-actions {


### PR DESCRIPTION
## Summary
- ensure lobby queries and lifecycle logic keep lobbies visible across devices, auto-expire idle rooms, and clean up host-owned records on navigation or match start
- rework the lobby detail experience so hosts and guests see dedicated controls with updated styling and documentation
- adjust match subscriptions and auth startup to avoid stale data and reflect the refreshed flow in the multiplayer schema docs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d809c5bc3c832a83153bc0f0d0e968