### PR TITLE
Handle optional triggers and phase locking

### DIFF
--- a/src/app/game/combat/blockers.js
+++ b/src/app/game/combat/blockers.js
@@ -21,7 +21,12 @@ export function prepareBlocks() {
   const defenders = game.players[defending].battlefield.filter((creature) => creature.type === 'creature');
   if (defenders.length === 0) {
     addLog([playerSegment(game.players[defending]), textSegment(' has no blockers.')]);
-    resolveCombat();
+    if (game.players[defending].isAI) {
+      resolveCombat();
+      return;
+    }
+    game.blocking.awaitingDefender = true;
+    requestRender();
     return;
   }
   if (game.players[defending].isAI) {

--- a/src/app/ui/views/game/controls.js
+++ b/src/app/ui/views/game/controls.js
@@ -155,12 +155,13 @@ export function renderGameControls({
   if (!game) return '';
   const localSeatIndex = getLocalSeatIndex();
   const isLocalTurn = game.currentPlayer === localSeatIndex;
+  const phaseLocked = Boolean(game.pendingAction);
 
   let mainButtonLabel = 'Next Phase';
   let showPhaseButton = showPhaseControls;
   switch (game.phase) {
     case 'main1':
-    mainButtonLabel = 'Go to Combat';
+      mainButtonLabel = 'Go to Combat';
       break;
     case 'main2':
       mainButtonLabel = 'End Turn';
@@ -172,10 +173,11 @@ export function renderGameControls({
       break;
   }
 
+  const declareBlockersDisabled = !canDeclareBlockers || phaseLocked;
   const blockingControls = shouldShowBlocking
     ? `
         <div class="control-row blockers">
-          <button class="primary" data-action="declare-blockers" ${canDeclareBlockers ? '' : 'disabled'}>Declare Blockers</button>
+          <button class="primary ${declareBlockersDisabled ? 'disabled' : ''}" data-action="declare-blockers" ${declareBlockersDisabled ? 'disabled' : ''}>Declare Blockers</button>
         </div>
       `
     : '';
@@ -200,10 +202,11 @@ export function renderGameControls({
       `
     : '';
 
+  const phaseButtonDisabled = !isLocalTurn || phaseLocked;
   const phaseControls = showPhaseButton
     ? `
         <div class="control-row phases">
-          <button class="primary" data-action="end-phase" ${!isLocalTurn ? 'disabled' : ''}>${mainButtonLabel}</button>
+          <button class="primary ${phaseButtonDisabled ? 'disabled' : ''}" data-action="end-phase" ${phaseButtonDisabled ? 'disabled' : ''}>${mainButtonLabel}</button>
         </div>
       `
     : '';


### PR DESCRIPTION
## Summary
- cancel optional attack triggers without valid targets instead of forcing a choice
- keep the blockers step active for human defenders even with no creatures and disable phase controls during pending actions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d82a13bb9c832a90deef92619650c3