### PR TITLE
Ensure multiplayer transactions apply rule scope first

### DIFF
--- a/src/app/multiplayer/rules.js
+++ b/src/app/multiplayer/rules.js
@@ -20,6 +20,23 @@ export function applyMultiplayerRuleParams(chunk) {
   if (!chunk || typeof chunk.ruleParams !== 'function') {
     return chunk;
   }
-  return chunk.ruleParams(MULTIPLAYER_RULE_PARAMS);
+  const ops = Array.isArray(chunk.__ops) ? chunk.__ops : null;
+  const alreadyApplied = Boolean(ops && ops.some((step) => step?.[0] === 'ruleParams'));
+  const withRuleParams = alreadyApplied
+    ? chunk
+    : chunk.ruleParams(MULTIPLAYER_RULE_PARAMS);
+
+  const finalOps = Array.isArray(withRuleParams?.__ops) ? withRuleParams.__ops : null;
+  if (!finalOps) {
+    return withRuleParams;
+  }
+
+  const ruleIndex = finalOps.findIndex((step) => step?.[0] === 'ruleParams');
+  if (ruleIndex > 0) {
+    const [ruleStep] = finalOps.splice(ruleIndex, 1);
+    finalOps.unshift(ruleStep);
+  }
+
+  return withRuleParams;
 }
 


### PR DESCRIPTION
## Summary
- ensure multiplayer transaction chunks always include the multiplayer rule params before any operations
- keep the generated rule-param step at the front of the tx so lobby writes land in the shared scope

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9b3c288c832a9219fd057373f66d