### PR TITLE
Fix multiplayer lobby subscription recursion

### DIFF
--- a/src/app/ui/multiplayer/events.js
+++ b/src/app/ui/multiplayer/events.js
@@ -736,10 +736,6 @@ async function maybeCleanupStaleLobbies(lobbies) {
 function refreshLobbySubscription() {
   cleanupLobbyListSubscription();
 
-  state.multiplayer.lobbyList.loading = true;
-  state.multiplayer.lobbyList.error = null;
-  requestRender();
-
   const query = {
     lobbies: {
       $: {
@@ -774,7 +770,15 @@ function refreshLobbySubscription() {
     return;
   }
 
-  state.multiplayer.lobbySubscription = unsubscribe;
+  if (typeof unsubscribe === 'function') {
+    state.multiplayer.lobbySubscription = unsubscribe;
+  } else {
+    console.warn('Unexpected lobby subscription handle; falling back to no-op close.');
+    state.multiplayer.lobbySubscription = () => {};
+  }
+  state.multiplayer.lobbyList.loading = true;
+  state.multiplayer.lobbyList.error = null;
+  requestRender();
   primeLobbyListing(query);
 }
 


### PR DESCRIPTION
## Summary
- defer the lobby list loading state update until after the InstantDB subscription is established to avoid recursive refresh loops
- add a defensive fallback when subscribeQuery returns a non-function handle

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da9f0f3680832a8adb575e8f567919