### PR TITLE
Fix lobby subscriptions and auto-join flow

### DIFF
--- a/src/app/state.js
+++ b/src/app/state.js
@@ -23,6 +23,7 @@ export const initialState = {
     activeLobby: null,
     lobbySubscription: null,
     activeLobbySubscription: null,
+    activeLobbySubscriptionId: null,
     cardCache: null,
     match: null,
     matchSubscription: null,
@@ -31,6 +32,7 @@ export const initialState = {
     currentMatchId: null,
     lastSequenceApplied: 0,
     replayingEvents: false,
+    autoJoinInFlight: null,
   },
   game: null,
   ui: {
@@ -80,6 +82,7 @@ export function resetToMenu() {
     state.multiplayer.activeLobbySubscription();
   }
   state.multiplayer.activeLobbySubscription = null;
+  state.multiplayer.activeLobbySubscriptionId = null;
   if (typeof state.multiplayer.matchSubscription === 'function') {
     state.multiplayer.matchSubscription();
   }
@@ -90,6 +93,7 @@ export function resetToMenu() {
   state.multiplayer.currentMatchId = null;
   state.multiplayer.lastSequenceApplied = 0;
   state.multiplayer.replayingEvents = false;
+  state.multiplayer.autoJoinInFlight = null;
   state.screen = 'menu';
   state.ui.previewCard = null;
   requestRender();


### PR DESCRIPTION
## Summary
- prevent runaway resubscriptions by tracking the active lobby subscription id and cleaning up state safely
- automatically claim the guest seat when a player opens an available lobby and reset join state when seats change
- cap the lobby list to 10 entries and extend multiplayer state bookkeeping for stability

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68dab012eba0832a9a11507a2e4018ab