### PR TITLE
Add mobile landscape wrapper for widescreen mode

### DIFF
--- a/src/app/ui/effects/index.js
+++ b/src/app/ui/effects/index.js
@@ -1,4 +1,5 @@
 import { attachParticleField, resetParticleFields } from './particleField.js';
+import { applyWideMobileOrientation } from '../widescreenview/mobile-orientation.js';
 
 const PARTICLE_SCREENS = new Set([
   'menu',
@@ -10,6 +11,7 @@ const PARTICLE_SCREENS = new Set([
 ]);
 
 export function enhanceView(root, screen) {
+  applyWideMobileOrientation(root);
   resetParticleFields();
   if (!PARTICLE_SCREENS.has(screen)) {
     return;

--- a/src/app/ui/widescreenview/index.js
+++ b/src/app/ui/widescreenview/index.js
@@ -36,27 +36,29 @@ export function renderGameWide() {
   const isHandOpen = state.ui.wideHandOpen || false;
 
   return `
-    <div class="view game-view wide-game-view">
-      ${renderWideBattlefield({ player, opponent, game })}
-      
-      <!-- Widescreen overlays -->
-      <div class="wide-overlays">
-        ${renderWideLifeGlobes({ player, opponent, game, localSeatIndex, opponentIndex })}
-        ${renderWidePlayerBars({ player, opponent, game, localSeatIndex, opponentIndex })}
-        ${renderWidePhaseBox(game)}
-        ${renderWideActiveSpellSlot(game)}
-        ${renderWideCombatBar(game)}
-        ${renderWideLogs({ battleLogEntries, spellLogEntries })}
-      </div>
+    <div class="wide-mobile-wrapper">
+      <div class="view game-view wide-game-view">
+        ${renderWideBattlefield({ player, opponent, game })}
 
-      ${renderWideHand(player, game, isHandOpen)}
-      ${renderWideSettingsMenu()}
-      ${renderWideCardPreview()}
-      ${renderTargetLines(game)}
-      ${renderAttackLines(game)}
-      ${renderCardPreviewModal(game)}
-      ${renderGraveyardModal(game)}
-      ${renderEndGameModal()}
+        <!-- Widescreen overlays -->
+        <div class="wide-overlays">
+          ${renderWideLifeGlobes({ player, opponent, game, localSeatIndex, opponentIndex })}
+          ${renderWidePlayerBars({ player, opponent, game, localSeatIndex, opponentIndex })}
+          ${renderWidePhaseBox(game)}
+          ${renderWideActiveSpellSlot(game)}
+          ${renderWideCombatBar(game)}
+          ${renderWideLogs({ battleLogEntries, spellLogEntries })}
+        </div>
+
+        ${renderWideHand(player, game, isHandOpen)}
+        ${renderWideSettingsMenu()}
+        ${renderWideCardPreview()}
+        ${renderTargetLines(game)}
+        ${renderAttackLines(game)}
+        ${renderCardPreviewModal(game)}
+        ${renderGraveyardModal(game)}
+        ${renderEndGameModal()}
+      </div>
     </div>
   `;
 }

--- a/src/app/ui/widescreenview/mobile-orientation.js
+++ b/src/app/ui/widescreenview/mobile-orientation.js
@@ -1,0 +1,93 @@
+let controller = null;
+
+class WideMobileOrientationController {
+  constructor(wrapper) {
+    this.wrapper = wrapper;
+    this.boundUpdate = this.update.bind(this);
+    this.onViewportChange = () => window.requestAnimationFrame(this.boundUpdate);
+
+    window.addEventListener('resize', this.onViewportChange);
+    window.addEventListener('orientationchange', this.onViewportChange);
+  }
+
+  update() {
+    const wrapper = this.wrapper;
+    if (!wrapper || !wrapper.isConnected) {
+      this.destroy();
+      return;
+    }
+
+    const content = wrapper.querySelector('.wide-game-view');
+    if (!content) {
+      return;
+    }
+
+    const isMobile = window.matchMedia('(max-width: 900px)').matches;
+    wrapper.classList.toggle('wide-mobile-active', isMobile);
+
+    if (!isMobile) {
+      wrapper.classList.remove('wide-mobile-portrait', 'wide-mobile-measuring');
+      wrapper.style.removeProperty('--wide-mobile-scale');
+      return;
+    }
+
+    wrapper.classList.add('wide-mobile-measuring');
+    wrapper.classList.remove('wide-mobile-portrait');
+    wrapper.style.setProperty('--wide-mobile-scale', '1');
+
+    const naturalWidth = content.offsetWidth;
+    const naturalHeight = content.offsetHeight;
+
+    wrapper.classList.remove('wide-mobile-measuring');
+
+    const portrait = window.innerHeight > window.innerWidth;
+    wrapper.classList.toggle('wide-mobile-portrait', portrait);
+
+    let availableWidth = window.innerWidth;
+    let availableHeight = window.innerHeight;
+    if (portrait) {
+      availableWidth = window.innerHeight;
+      availableHeight = window.innerWidth;
+    }
+
+    const scale = Math.min(availableWidth / naturalWidth, availableHeight / naturalHeight, 1);
+    wrapper.style.setProperty('--wide-mobile-scale', scale.toFixed(4));
+  }
+
+  destroy() {
+    window.removeEventListener('resize', this.onViewportChange);
+    window.removeEventListener('orientationchange', this.onViewportChange);
+    if (this.wrapper) {
+      this.wrapper.classList.remove('wide-mobile-active', 'wide-mobile-portrait', 'wide-mobile-measuring');
+      this.wrapper.style.removeProperty('--wide-mobile-scale');
+    }
+    this.wrapper = null;
+    if (controller === this) {
+      controller = null;
+    }
+  }
+}
+
+export function applyWideMobileOrientation(root) {
+  const wrapper = root.querySelector('.wide-mobile-wrapper');
+
+  if (!wrapper) {
+    if (controller) {
+      controller.destroy();
+      controller = null;
+    }
+    return;
+  }
+
+  if (controller && controller.wrapper === wrapper) {
+    controller.update();
+    return;
+  }
+
+  if (controller) {
+    controller.destroy();
+  }
+
+  controller = new WideMobileOrientationController(wrapper);
+  controller.update();
+}

--- a/src/app/ui/widescreenview/styles.css
+++ b/src/app/ui/widescreenview/styles.css
@@ -93,6 +93,62 @@
   color: #fef2f2;
 }
 
+/* Mobile orientation wrapper */
+.wide-mobile-wrapper {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  --wide-mobile-scale: 1;
+}
+
+@media (min-width: 901px) {
+  .wide-mobile-wrapper {
+    position: fixed;
+    inset: 0;
+  }
+
+  .wide-mobile-wrapper .wide-game-view {
+    position: fixed;
+    top: 0;
+    left: 0;
+    transform: none !important;
+  }
+}
+
+@media (max-width: 900px) {
+  .wide-mobile-wrapper {
+    background: transparent;
+  }
+
+  .wide-mobile-wrapper .wide-game-view {
+    position: absolute;
+    top: 0;
+    left: 0;
+    transform-origin: center;
+  }
+
+  .wide-mobile-wrapper.wide-mobile-active .wide-game-view {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) scale(var(--wide-mobile-scale));
+  }
+
+  .wide-mobile-wrapper.wide-mobile-active.wide-mobile-portrait .wide-game-view {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%) rotate(90deg) scale(var(--wide-mobile-scale));
+  }
+
+  .wide-mobile-wrapper.wide-mobile-measuring .wide-game-view {
+    transform: none !important;
+    top: 0;
+    left: 0;
+    position: absolute;
+  }
+}
+
 /* Widescreen Game View */
 .wide-game-view {
   position: fixed;


### PR DESCRIPTION
## Summary
- wrap the widescreen game markup in a mobile shell so it can be rotated and scaled on phones
- add responsive styles and a controller that rotates and scales the view to landscape when a small screen is detected
- invoke the new orientation controller during view enhancement so the wrapper stays synced with re-renders

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfd84163b4832a8c9e97ffaa057a4a